### PR TITLE
Feature/cli version option 18

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { Command } from 'commander';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,6 @@
 #! /usr/bin/env node
-
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { Command } from 'commander';
 import cmdAdmin from './admin/cmd';
 import * as cmdUser from './user/cmd';
@@ -12,6 +13,13 @@ import cmdTranscribe from './transcribe/cmd';
 import cmdDb from './db/cmd';
 
 const cli = new Command();
+
+// Read package.json
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+);
+
+cli.version(packageJson.version, '-v, --version', 'Output the current version');
 
 cli
   .configureHelp({ showGlobalOptions: true })


### PR DESCRIPTION
# Add Version Option to CLI

This PR implements a new feature allowing users to check the version of the CLI tool using the `--version` or `-v` flag.

## Changes

- Added functionality to read the version from `package.json`
- Implemented the version option using Commander.js in `cli.ts`
- The CLI now responds to `osc --version` and `osc -v` commands

## Implementation Details

- Used `fs.readFileSync` to read the `package.json` file
- Utilized the `path.join` method to ensure cross-platform compatibility
- Integrated the version information with Commander.js's `version` method

## Testing

To test this feature:

1. Build the project: `npm run build`
2. Install the CLI globally: `cd packages/cli && npm install -g .`
3. Run `osc --version` or `osc -v` from any directory

Expected output: The current version number (e.g., `0.10.1`)

Closes #18