### PR TITLE
fix: unclear usage for pipeline transcoding

### DIFF
--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -88,10 +88,8 @@ osc transcode \
 ### Transcode and create streaming package using SVT Encore and Shaka Packager
 
 ```
-osc transcode -b \
-  https://testcontent.eyevinn.technology/mp4/stswe-tvplus-promo.mp4 \
-  s3://lab-testcontent-store/birme/ \
-  s3://lab-testcontent-store/birme/output/
+osc pipeline create s3://lab-testcontent-store/birme/output/
+osc pipepline transcode https://testcontent.eyevinn.technology/mp4/stswe-tvplus-promo.mp4
 ```
 
 ### Compare two video files using VMAF

--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -89,7 +89,7 @@ osc transcode \
 
 ```
 osc pipeline create s3://lab-testcontent-store/birme/output/
-osc pipepline transcode https://testcontent.eyevinn.technology/mp4/stswe-tvplus-promo.mp4
+osc pipeline transcode https://testcontent.eyevinn.technology/mp4/stswe-tvplus-promo.mp4
 ```
 
 ### Compare two video files using VMAF


### PR DESCRIPTION
For transcoding and packaging using a pipeline the `-b` option to transcode command is replaced with

```bash
% osc pipeline create <dest-bucket>
% osc pipeline transcode <source-file>
```
