### PR TITLE
feat: add support for using existing output bucket in VOD pipeline

### DIFF
--- a/packages/cli/src/vod/cmd.ts
+++ b/packages/cli/src/vod/cmd.ts
@@ -15,13 +15,25 @@ export function cmdVod() {
     )
     .argument('<name>', 'Name of VOD Pipeline')
     .argument('<source>', 'Source URL')
+    .option('--output-bucket-name <name>', 'Name of existing output bucket')
+    .option('--access-key-id <id>', 'Access key ID for existing output bucket')
+    .option(
+      '--secret-access-key <key>',
+      'Secret access key for existing output bucket'
+    )
+    .option('--endpoint <url>', 'Endpoint URL for existing output bucket')
     .action(async (name, source, options, command) => {
       try {
         const globalOpts = command.optsWithGlobals();
         const environment = globalOpts?.env || 'prod';
         const ctx = new Context({ environment });
         Log().info('Creating VOD pipeline');
-        const pipeline = await createVodPipeline(name, ctx);
+        const pipeline = await createVodPipeline(name, ctx, {
+          outputBucketName: options.outputBucketName,
+          accessKeyId: options.accessKeyId,
+          secretAccessKey: options.secretAccessKey,
+          endpoint: options.endpoint
+        });
         Log().info('VOD pipeline created, starting job to create VOD');
         const job = await createVod(pipeline, source, ctx);
         if (job) {


### PR DESCRIPTION
## Summary
- Add CLI options to use existing output bucket instead of creating new one
- Support configuring existing bucket name, access keys, and endpoint
- Update packager creation to handle output folder changes and recreate instances when needed
- Fix VOD URL generation to use correct bucket name from pipeline configuration

## Test plan
- [ ] Test VOD creation with new bucket (existing functionality)
- [ ] Test VOD creation with existing bucket using new CLI options
- [ ] Verify VOD URLs are generated correctly for both scenarios
- [ ] Test packager instance recreation when output folder changes

🤖 Generated with [Claude Code](https://claude.ai/code)