### PR TITLE
feat: add saveSecret function and use for packager OSC token

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -352,3 +352,26 @@ export async function waitForInstanceReady(
     }
   }
 }
+
+export async function saveSecret(
+  serviceId: string,
+  name: string,
+  value: string,
+  ctx: Context
+) {
+  const secretsUrl = new URL(
+    `/mysecrets/${serviceId}`,
+    `https://deploy.svc.${ctx.getEnvironment()}.osaas.io`
+  );
+  await createFetch(secretsUrl, {
+    method: 'POST',
+    body: JSON.stringify({
+      secretName: name,
+      secretData: value
+    }),
+    headers: {
+      'x-pat-jwt': `Bearer ${ctx.getPersonalAccessToken()}`,
+      'Content-Type': 'application/json'
+    }
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,8 @@ export {
   instanceValue,
   valueOrSecret,
   isValidInstanceName,
-  waitForInstanceReady
+  waitForInstanceReady,
+  saveSecret
 } from './core';
 export {
   listSubscriptions,

--- a/packages/transcode/src/vodpipeline.ts
+++ b/packages/transcode/src/vodpipeline.ts
@@ -4,6 +4,7 @@ import {
   getPortsForInstance,
   isValidInstanceName,
   removeInstance,
+  saveSecret,
   waitForInstanceReady
 } from '@osaas/client-core';
 import {
@@ -20,8 +21,7 @@ import {
   createEyevinnEncoreCallbackListenerInstance,
   createEyevinnEncorePackagerInstance,
   createMinioMinioInstance,
-  createValkeyIoValkeyInstance,
-  getEyevinnEncorePackagerInstance
+  createValkeyIoValkeyInstance
 } from '@osaas/client-services';
 import * as Minio from 'minio';
 import { delay } from './util';
@@ -197,6 +197,12 @@ async function createPackager(
     instance = undefined;
   }
   if (!instance) {
+    await saveSecret(
+      'eyevinn-encore-packager',
+      'osctoken',
+      ctx.getPersonalAccessToken() || '',
+      ctx
+    );
     const config: EyevinnEncorePackagerConfig = {
       name,
       RedisUrl: redisUrl,


### PR DESCRIPTION
## Summary
- Add `saveSecret` function to core module for managing service secrets
- Export `saveSecret` from core package for external use
- Automatically save OSC token as secret when creating packager instances
- Clean up unused imports in transcode module

## Test plan
- [ ] Verify saveSecret function correctly stores secrets via API
- [ ] Test packager creation with automatic OSC token secret storage
- [ ] Confirm no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)