### PR TITLE
feat: add --safe-name option to strip invalid characters from instance names

### DIFF
--- a/packages/cli/src/user/cmd.ts
+++ b/packages/cli/src/user/cmd.ts
@@ -10,7 +10,7 @@ import {
   removeInstance
 } from '@osaas/client-core';
 import { Command } from 'commander';
-import { confirm, instanceOptsToPayload } from './util';
+import { confirm, instanceOptsToPayload, makeSafeName } from './util';
 import { restartInstance } from '@osaas/client-core/lib/core';
 
 export function cmdList() {
@@ -48,6 +48,7 @@ export function cmdCreate() {
     .description('Create a service instance')
     .argument('<serviceId>', 'The Service Id')
     .argument('<name>', 'The instance name')
+    .option('--safe-name', 'Strip invalid characters from the name')
     .option(
       '-o, --instance-options [instanceOptions...]',
       'Instance options as key value pairs (e.g. -o key1=value1 -o key2=value2)'
@@ -56,7 +57,7 @@ export function cmdCreate() {
       try {
         const globalOpts = command.optsWithGlobals();
         const payload = instanceOptsToPayload(options.instanceOptions);
-        payload['name'] = name;
+        payload['name'] = options.safeName ? makeSafeName(name) : name;
         const environment = globalOpts?.env || 'prod';
         const ctx = new Context({ environment });
         const serviceAccessToken = await ctx.getServiceAccessToken(serviceId);

--- a/packages/cli/src/user/util.test.ts
+++ b/packages/cli/src/user/util.test.ts
@@ -1,4 +1,4 @@
-import { instanceOptsToPayload } from './util';
+import { instanceOptsToPayload, makeSafeName } from './util';
 
 describe('util functions', () => {
   test('can parse instance options containing =', () => {
@@ -11,5 +11,31 @@ describe('util functions', () => {
     const opts = [`cmdLineArgs=-i hejhopp=tjohopp`];
     const payload = instanceOptsToPayload(opts);
     expect(payload).toEqual({ cmdLineArgs: '-i hejhopp=tjohopp' });
+  });
+
+  describe('makeSafeName', () => {
+    test('should remove dashes from instance name', () => {
+      expect(makeSafeName('my-test-instance')).toBe('mytestinstance');
+    });
+
+    test('should preserve alphanumeric characters', () => {
+      expect(makeSafeName('test123')).toBe('test123');
+    });
+
+    test('should convert to lowercase', () => {
+      expect(makeSafeName('MyTestInstance')).toBe('mytestinstance');
+    });
+
+    test('should remove all non-alphanumeric characters', () => {
+      expect(makeSafeName('My-Test_Instance@123!')).toBe('mytestinstance123');
+    });
+
+    test('should handle empty string', () => {
+      expect(makeSafeName('')).toBe('');
+    });
+
+    test('should handle string with only special characters', () => {
+      expect(makeSafeName('!@#$%^&*()')).toBe('');
+    });
   });
 });

--- a/packages/cli/src/user/util.ts
+++ b/packages/cli/src/user/util.ts
@@ -28,6 +28,10 @@ export function instanceOptsToPayload(opts: string[] | undefined) {
   return payload;
 }
 
+export function makeSafeName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
 export async function confirm(message: string | undefined): Promise<void> {
   const rl = readline.createInterface({
     input: process.stdin,


### PR DESCRIPTION
## Summary
- Add `--safe-name` option to the `create` command that strips invalid characters from instance names
- Extract `makeSafeName` utility function that converts names to lowercase and removes non-alphanumeric characters  
- Add comprehensive unit tests for the `makeSafeName` function

## Test plan
- [x] Unit tests verify dashes and special characters are removed
- [x] Unit tests verify alphanumeric characters are preserved
- [x] Unit tests verify conversion to lowercase
- [x] Unit tests cover edge cases (empty strings, special characters only)

🤖 Generated with [Claude Code](https://claude.ai/code)