### PR TITLE
feat: add instance scaling commands to manage service replicas

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,6 +39,8 @@ cli.addCommand(cmdUser.cmdDescribe());
 cli.addCommand(cmdUser.cmdRemove());
 cli.addCommand(cmdUser.cmdLogs());
 cli.addCommand(cmdUser.cmdRestart());
+cli.addCommand(cmdUser.cmdGetInstanceReplicas());
+cli.addCommand(cmdUser.cmdSetInstanceReplicas());
 cli.addCommand(cmdUser.cmdServiceAccessToken());
 cli.addCommand(cmdUser.cmdReservedNodes());
 cli.addCommand(cmdUser.cmdSecrets());

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -321,6 +321,87 @@ export async function restartInstance(
   });
 }
 
+/**
+ * Get scaling information for an instance of a service in Open Source Cloud
+ * @memberof module:@osaas/client-core
+ * @param {Context} context - Open Source Cloud configuration context
+ * @param {string} serviceId - The service identifier
+ * @param {string} name - The name of the service instance
+ * @param {string} token - Service access token
+ * @returns {Object} - Scaling information with actualReplicas and desiredReplicas
+ */
+export async function getInstanceScaling(
+  context: Context,
+  serviceId: string,
+  name: string,
+  token: string
+): Promise<{ actualReplicas: number; desiredReplicas: number }> {
+  try {
+    const scaleUrl = await getInstanceLink(
+      context,
+      token,
+      serviceId,
+      name,
+      'scale'
+    );
+    return await createFetch<{
+      actualReplicas: number;
+      desiredReplicas: number;
+    }>(scaleUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (err) {
+    Log().debug(err);
+    throw new Error(
+      `Instance ${name} of service ${serviceId} does not support scaling`
+    );
+  }
+}
+
+/**
+ * Scale the number of replicas for an instance of a service in Open Source Cloud
+ * @memberof module:@osaas/client-core
+ * @param {Context} context - Open Source Cloud configuration context
+ * @param {string} serviceId - The service identifier
+ * @param {string} name - The name of the service instance
+ * @param {number} replicas - Desired number of replicas
+ * @param {string} token - Service access token
+ */
+export async function scaleInstanceReplicas(
+  context: Context,
+  serviceId: string,
+  name: string,
+  replicas: number,
+  token: string
+) {
+  try {
+    const scaleUrl = await getInstanceLink(
+      context,
+      token,
+      serviceId,
+      name,
+      'scale'
+    );
+    await createFetch(scaleUrl, {
+      method: 'PUT',
+      body: JSON.stringify({ desiredReplicas: replicas }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (err) {
+    Log().debug(err);
+    throw new Error(
+      `Instance ${name} of service ${serviceId} could not be scaled`
+    );
+  }
+}
+
 export function instanceValue(
   instance: { [key: string]: string },
   key: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,10 @@ export {
   valueOrSecret,
   isValidInstanceName,
   waitForInstanceReady,
-  saveSecret
+  saveSecret,
+  restartInstance,
+  getInstanceScaling,
+  scaleInstanceReplicas
 } from './core';
 export {
   listSubscriptions,


### PR DESCRIPTION
## Summary
- Add `get-instance-replicas` command to view current actual and desired replica counts for service instances
- Add `set-instance-replicas` command to set the desired number of replicas for service instances
- Export new scaling functions from core module for CLI usage

## Test plan
- [ ] Test `get-instance-replicas` command with valid service and instance
- [ ] Test `set-instance-replicas` command to scale instances up and down
- [ ] Verify error handling for instances that don't support scaling
- [ ] Confirm CLI help text displays correctly for new commands

🤖 Generated with [Claude Code](https://claude.ai/code)