### PR TITLE
feat: add custom AWS credentials and S3 endpoint support for VMAF

### DIFF
--- a/packages/cli/src/vmaf/cmd.ts
+++ b/packages/cli/src/vmaf/cmd.ts
@@ -20,6 +20,22 @@ export default function cmdCompare() {
       '<result>',
       'URL where to store the result (supported protocols: s3)'
     )
+    .option(
+      '--aws-access-key-id <awsAccessKeyId>',
+      'AWS Access Key ID (overrides AWS_ACCESS_KEY_ID env var)'
+    )
+    .option(
+      '--aws-secret-access-key <awsSecretAccessKey>',
+      'AWS Secret Access Key (overrides AWS_SECRET_ACCESS_KEY env var)'
+    )
+    .option(
+      '--aws-session-token <awsSessionToken>',
+      'AWS Session Token (overrides AWS_SESSION_TOKEN env var)'
+    )
+    .option(
+      '--s3-endpoint-url <s3EndpointUrl>',
+      'S3 Endpoint URL (overrides S3_ENDPOINT_URL env var)'
+    )
     .action(async (reference, distorted, result, options, command) => {
       try {
         const globalOpts = command.optsWithGlobals();
@@ -29,7 +45,16 @@ export default function cmdCompare() {
           ctx,
           new URL(reference),
           new URL(distorted),
-          new URL(result)
+          new URL(result),
+          {
+            awsAccessKeyId:
+              options.awsAccessKeyId || process.env.AWS_ACCESS_KEY_ID,
+            awsSecretAccessKey:
+              options.awsSecretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
+            awsSessionToken:
+              options.awsSessionToken || process.env.AWS_SESSION_TOKEN,
+            s3EndpointUrl: options.s3EndpointUrl || process.env.S3_ENDPOINT_URL
+          }
         );
         Log().info(`VMAF comparison result stored at ${resultUrl.toString()}`);
       } catch (err) {


### PR DESCRIPTION
## Summary
• Added CLI options to override AWS credentials (access key, secret key, session token)
• Added S3 endpoint URL configuration option for custom S3-compatible services  
• Enhanced vmafCompare function to accept optional AWS configuration parameters

## Test plan
- [ ] Test VMAF comparison with default environment variables
- [ ] Test VMAF comparison with custom AWS credentials via CLI options
- [ ] Test VMAF comparison with custom S3 endpoint URL
- [ ] Verify backwards compatibility with existing usage

🤖 Generated with [Claude Code](https://claude.ai/code)