### PR TITLE
feat(mobile-backend): add auth module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3174,6 +3174,20 @@
         "@octokit/openapi-types": "^18.0.0"
       }
     },
+    "node_modules/@openauthjs/openauth": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@openauthjs/openauth/-/openauth-0.4.3.tgz",
+      "integrity": "sha512-RlnjqvHzqcbFVymEwhlUEuac4utA5h4nhSK/i2szZuQmxTIqbGUxZ+nM+avM+VV4Ing+/ZaNLKILoXS3yrkOOw==",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0-beta.3",
+        "aws4fetch": "1.0.20",
+        "jose": "5.9.6"
+      },
+      "peerDependencies": {
+        "arctic": "^2.2.2",
+        "hono": "^4.0.0"
+      }
+    },
     "node_modules/@osaas/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -3213,6 +3227,58 @@
     "node_modules/@osaas/client-web": {
       "resolved": "packages/web",
       "link": true
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oslojs/jwt": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
+      "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/encoding": "0.4.1"
+      }
+    },
+    "node_modules/@oslojs/jwt/node_modules/@oslojs/encoding": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
+      "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3922,6 +3988,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0-beta.3.tgz",
+      "integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "dev": true,
@@ -4568,6 +4640,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/arctic": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/arctic/-/arctic-2.3.4.tgz",
+      "integrity": "sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/crypto": "1.0.1",
+        "@oslojs/encoding": "1.1.0",
+        "@oslojs/jwt": "0.2.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
@@ -4638,6 +4722,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.7.2",
@@ -7522,6 +7612,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "dev": true,
@@ -8739,6 +8839,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -13439,7 +13548,10 @@
     "packages/mobile-backend": {
       "name": "@osaas/client-mobile-backend",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@openauthjs/openauth": "^0.4.3"
+      }
     },
     "packages/services": {
       "name": "@osaas/client-services",

--- a/packages/mobile-backend/jest.config.js
+++ b/packages/mobile-backend/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-node-single-context',
-  modulePathIgnorePatterns: ['lib/']
+  modulePathIgnorePatterns: ['lib/'],
+  moduleNameMapper: {
+    '^@openauthjs/openauth/client$':
+      '<rootDir>/src/__mocks__/@openauthjs/openauth/client.ts'
+  }
 };

--- a/packages/mobile-backend/package.json
+++ b/packages/mobile-backend/package.json
@@ -23,5 +23,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@openauthjs/openauth": "^0.4.3"
   }
 }

--- a/packages/mobile-backend/src/__mocks__/@openauthjs/openauth/client.ts
+++ b/packages/mobile-backend/src/__mocks__/@openauthjs/openauth/client.ts
@@ -1,0 +1,6 @@
+export const createClient = jest.fn(() => ({
+  authorize: jest.fn(),
+  exchange: jest.fn(),
+  verify: jest.fn(),
+  refresh: jest.fn()
+}));

--- a/packages/mobile-backend/src/__tests__/auth.test.ts
+++ b/packages/mobile-backend/src/__tests__/auth.test.ts
@@ -1,0 +1,243 @@
+import { AuthModule, AuthTokens } from '../auth';
+import { MobileBackendClient } from '../index';
+
+const mockAuthorize = jest.fn();
+const mockExchange = jest.fn();
+const mockVerify = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock('@openauthjs/openauth/client', () => ({
+  createClient: jest.fn(() => ({
+    authorize: mockAuthorize,
+    exchange: mockExchange,
+    verify: mockVerify,
+    refresh: mockRefresh
+  }))
+}));
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256' })).toString(
+    'base64url'
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
+describe('AuthModule', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('authorize()', () => {
+    it('returns url and challenge from openauth client', async () => {
+      const expected = {
+        url: 'https://auth.example.com/authorize?state=abc',
+        challenge: { state: 'abc', verifier: 'verifier-xyz' }
+      };
+      mockAuthorize.mockResolvedValueOnce(expected);
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      const result = await mod.authorize('https://app.example.com/callback', {
+        pkce: true
+      });
+
+      expect(mockAuthorize).toHaveBeenCalledWith(
+        'https://app.example.com/callback',
+        'code',
+        { pkce: true }
+      );
+      expect(result).toEqual(expected);
+    });
+
+    it('passes provider option when supplied', async () => {
+      mockAuthorize.mockResolvedValueOnce({
+        url: 'https://auth.example.com/authorize',
+        challenge: { state: 'x' }
+      });
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      await mod.authorize('https://app.example.com/callback', {
+        provider: 'email'
+      });
+
+      expect(mockAuthorize).toHaveBeenCalledWith(
+        'https://app.example.com/callback',
+        'code',
+        { provider: 'email' }
+      );
+    });
+  });
+
+  describe('exchange()', () => {
+    it('stores tokens on success and returns them', async () => {
+      const tokens: AuthTokens = {
+        access: makeJwt({ sub: 'user-123' }),
+        refresh: 'refresh-tok'
+      };
+      mockExchange.mockResolvedValueOnce({ err: false, tokens });
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      const result = await mod.exchange(
+        'code-abc',
+        'https://app.example.com/callback'
+      );
+
+      expect(result).toEqual({ err: false, tokens });
+      expect(mod.getAuthHeader()).toBe(`Bearer ${tokens.access}`);
+    });
+
+    it('passes verifier for PKCE flow', async () => {
+      const tokens: AuthTokens = {
+        access: makeJwt({ sub: 'user-123' }),
+        refresh: 'refresh-tok'
+      };
+      mockExchange.mockResolvedValueOnce({ err: false, tokens });
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      await mod.exchange(
+        'code-abc',
+        'https://app.example.com/callback',
+        'my-verifier'
+      );
+
+      expect(mockExchange).toHaveBeenCalledWith(
+        'code-abc',
+        'https://app.example.com/callback',
+        'my-verifier'
+      );
+    });
+
+    it('does not store tokens on error and returns error result', async () => {
+      const errorResult = { err: new Error('InvalidAuthorizationCode') };
+      mockExchange.mockResolvedValueOnce(errorResult);
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      const result = await mod.exchange(
+        'bad-code',
+        'https://app.example.com/callback'
+      );
+
+      expect(result).toEqual(errorResult);
+      expect(mod.getAuthHeader()).toBeUndefined();
+    });
+  });
+
+  describe('setTokens()', () => {
+    it('stores tokens so getAuthHeader returns Bearer value', () => {
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      mod.setTokens({ access: 'access-tok', refresh: 'refresh-tok' });
+
+      expect(mod.getAuthHeader()).toBe('Bearer access-tok');
+    });
+  });
+
+  describe('verify()', () => {
+    it('delegates to openauth client verify', async () => {
+      const verifyResult = {
+        subject: { type: 'user', properties: { id: '1' } }
+      };
+      mockVerify.mockResolvedValueOnce(verifyResult);
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      const subjects = {};
+      const result = await mod.verify(subjects, 'some-access-token', {
+        refresh: 'some-refresh-token'
+      });
+
+      expect(mockVerify).toHaveBeenCalledWith(subjects, 'some-access-token', {
+        refresh: 'some-refresh-token'
+      });
+      expect(result).toEqual(verifyResult);
+    });
+  });
+
+  describe('refresh()', () => {
+    it('delegates to openauth client refresh', async () => {
+      const refreshResult = {
+        err: false,
+        tokens: {
+          access: 'new-access',
+          refresh: 'new-refresh',
+          expiresIn: 3600
+        }
+      };
+      mockRefresh.mockResolvedValueOnce(refreshResult);
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      const result = await mod.refresh('old-refresh-token', {
+        access: 'old-access-token'
+      });
+
+      expect(mockRefresh).toHaveBeenCalledWith('old-refresh-token', {
+        access: 'old-access-token'
+      });
+      expect(result).toEqual(refreshResult);
+    });
+  });
+
+  describe('getUserId()', () => {
+    it('decodes sub claim from stored JWT access token', async () => {
+      const jwt = makeJwt({ sub: 'user-123', iat: 1700000000 });
+      mockExchange.mockResolvedValueOnce({
+        err: false,
+        tokens: { access: jwt, refresh: 'refresh-tok' }
+      });
+
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      await mod.exchange('code', 'https://app.example.com/callback');
+
+      expect(mod.getUserId()).toBe('user-123');
+    });
+
+    it('returns undefined when no tokens are stored', () => {
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      expect(mod.getUserId()).toBeUndefined();
+    });
+
+    it('returns undefined for a malformed token', () => {
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      mod.setTokens({ access: 'not.a.valid.jwt.here.extra', refresh: '' });
+      // still 3 parts after split? 'not.a.valid' has 3 — but payload won't have sub
+      mod.setTokens({ access: 'onlyone', refresh: '' });
+      expect(mod.getUserId()).toBeUndefined();
+    });
+  });
+
+  describe('getAuthHeader()', () => {
+    it('returns undefined when no tokens stored', () => {
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      expect(mod.getAuthHeader()).toBeUndefined();
+    });
+
+    it('returns Bearer header after tokens are set', () => {
+      const mod = new AuthModule('https://auth.example.com', 'my-client');
+      mod.setTokens({ access: 'my-access-token', refresh: 'my-refresh' });
+      expect(mod.getAuthHeader()).toBe('Bearer my-access-token');
+    });
+  });
+});
+
+describe('MobileBackendClient.auth', () => {
+  it('throws when auth config is not provided', () => {
+    const client = new MobileBackendClient({ sat: 'test-sat' });
+    expect(() => client.auth).toThrow(
+      'auth configuration is required to use the auth module'
+    );
+  });
+
+  it('returns an AuthModule instance when auth config is provided', () => {
+    const client = new MobileBackendClient({
+      auth: { issuer: 'https://auth.example.com', clientID: 'my-app' }
+    });
+    expect(client.auth).toBeInstanceOf(AuthModule);
+  });
+
+  it('returns the same AuthModule instance on repeated access', () => {
+    const client = new MobileBackendClient({
+      auth: { issuer: 'https://auth.example.com', clientID: 'my-app' }
+    });
+    const first = client.auth;
+    const second = client.auth;
+    expect(first).toBe(second);
+  });
+});

--- a/packages/mobile-backend/src/auth.ts
+++ b/packages/mobile-backend/src/auth.ts
@@ -1,0 +1,96 @@
+import { createClient } from '@openauthjs/openauth/client';
+import type {
+  AuthorizeResult,
+  ExchangeSuccess,
+  ExchangeError,
+  RefreshSuccess,
+  RefreshError,
+  VerifyResult,
+  VerifyError
+} from '@openauthjs/openauth/client';
+
+export type {
+  AuthorizeResult,
+  ExchangeSuccess,
+  ExchangeError,
+  RefreshSuccess,
+  RefreshError,
+  VerifyResult,
+  VerifyError
+};
+
+export interface AuthTokens {
+  access: string;
+  refresh: string;
+}
+
+export class AuthModule {
+  private openauth: ReturnType<typeof createClient>;
+  private tokens?: AuthTokens;
+
+  constructor(issuer: string, clientID: string) {
+    this.openauth = createClient({ issuer, clientID });
+  }
+
+  async authorize(
+    redirectUri: string,
+    opts?: { pkce?: boolean; provider?: string }
+  ): Promise<AuthorizeResult> {
+    return this.openauth.authorize(redirectUri, 'code', opts);
+  }
+
+  async exchange(
+    code: string,
+    redirectUri: string,
+    verifier?: string
+  ): Promise<ExchangeSuccess | ExchangeError> {
+    const result = await this.openauth.exchange(code, redirectUri, verifier);
+    if (!result.err) {
+      this.tokens = {
+        access: result.tokens.access,
+        refresh: result.tokens.refresh
+      };
+    }
+    return result;
+  }
+
+  setTokens(tokens: AuthTokens): void {
+    this.tokens = tokens;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async verify(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjects: any,
+    token: string,
+    opts?: { refresh?: string }
+  ): Promise<VerifyResult | VerifyError> {
+    return this.openauth.verify(subjects, token, opts);
+  }
+
+  async refresh(
+    refreshToken: string,
+    opts?: { access?: string }
+  ): Promise<RefreshSuccess | RefreshError> {
+    return this.openauth.refresh(refreshToken, opts);
+  }
+
+  getUserId(): string | undefined {
+    if (!this.tokens?.access) return undefined;
+    try {
+      const parts = this.tokens.access.split('.');
+      if (parts.length !== 3) return undefined;
+      const payload = JSON.parse(
+        Buffer.from(parts[1], 'base64').toString('utf-8')
+      );
+      return payload.sub as string | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  getAuthHeader(): string | undefined {
+    if (!this.tokens?.access) return undefined;
+    return `Bearer ${this.tokens.access}`;
+  }
+}

--- a/packages/mobile-backend/src/index.ts
+++ b/packages/mobile-backend/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from './types';
 import { ImageModule, ImageTransformOptions } from './image';
 import { DatabaseModule, DatabaseError } from './database';
+import { AuthModule, AuthTokens } from './auth';
 
 export {
   MobileBackendConfig,
@@ -17,13 +18,16 @@ export {
   ImageModule,
   ImageTransformOptions,
   DatabaseModule,
-  DatabaseError
+  DatabaseError,
+  AuthModule,
+  AuthTokens
 };
 
 export class MobileBackendClient {
   private config: MobileBackendConfig;
   private _image?: ImageModule;
   private _db?: DatabaseModule;
+  private _auth?: AuthModule;
 
   constructor(config: MobileBackendConfig) {
     this.config = config;
@@ -54,5 +58,20 @@ export class MobileBackendClient {
       );
     }
     return this._db;
+  }
+
+  get auth(): AuthModule {
+    if (!this._auth) {
+      if (!this.config.auth) {
+        throw new Error(
+          'auth configuration is required to use the auth module'
+        );
+      }
+      this._auth = new AuthModule(
+        this.config.auth.issuer,
+        this.config.auth.clientID
+      );
+    }
+    return this._auth;
   }
 }

--- a/packages/mobile-backend/src/openauth.d.ts
+++ b/packages/mobile-backend/src/openauth.d.ts
@@ -1,0 +1,70 @@
+declare module '@openauthjs/openauth/client' {
+  export interface AuthorizeResult {
+    url: string;
+    challenge?: { state: string; verifier: string };
+  }
+
+  export interface OpenAuthTokens {
+    access: string;
+    refresh: string;
+  }
+
+  export interface ExchangeSuccess {
+    err?: false;
+    tokens: OpenAuthTokens;
+  }
+
+  export interface ExchangeError {
+    err: { type: string };
+    tokens?: never;
+  }
+
+  export interface RefreshSuccess {
+    err?: false;
+    tokens: OpenAuthTokens;
+  }
+
+  export interface RefreshError {
+    err: { type: string };
+    tokens?: never;
+  }
+
+  export interface VerifyResult {
+    err?: false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subject: any;
+    tokens?: OpenAuthTokens;
+  }
+
+  export interface VerifyError {
+    err: { type: string };
+  }
+
+  interface OpenAuthClient {
+    authorize(
+      redirectUri: string,
+      responseType: 'code' | 'token',
+      opts?: { pkce?: boolean; provider?: string }
+    ): Promise<AuthorizeResult>;
+    exchange(
+      code: string,
+      redirectUri: string,
+      verifier?: string
+    ): Promise<ExchangeSuccess | ExchangeError>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    verify(
+      subjects: any,
+      token: string,
+      opts?: { refresh?: string }
+    ): Promise<VerifyResult | VerifyError>;
+    refresh(
+      refreshToken: string,
+      opts?: { access?: string }
+    ): Promise<RefreshSuccess | RefreshError>;
+  }
+
+  export function createClient(opts: {
+    issuer: string;
+    clientID: string;
+  }): OpenAuthClient;
+}


### PR DESCRIPTION
## Summary
- Adds `AuthModule` wrapping `@openauthjs/openauth/client`
- Supports email+code auth flow (authorize, exchange, verify, refresh)
- Token management with `setTokens()`, `getUserId()`, `getAuthHeader()`
- JWT subject decoding without verification (client-side only)
- Local type declarations for TS 4.9 compatibility (openauth uses TS 5+ features)
- Jest mock via moduleNameMapper for subpath export resolution

Closes #101
Part of [Eyevinn/osaas-app#2605](https://github.com/Eyevinn/osaas-app/issues/2605)

🤖 Generated with [Claude Code](https://claude.ai/code)