### PR TITLE
fix(cli): isolate per-tenant error handling in remove-exceeding-tenant-instances

### DIFF
--- a/packages/cli/src/admin/cmd.ts
+++ b/packages/cli/src/admin/cmd.ts
@@ -97,28 +97,36 @@ export default function cmdAdmin() {
         const tenantsExceedingCount = tenantsExceeding.length;
         for (const tenant of tenantsExceeding) {
           if (tenantPlanMap[tenant.tenantId]?.planType === 'FREE') {
-            const instancesToRemove = await getInstancesToRemove(
-              tenant.tenantId,
-              environment
-            );
-            if (instancesToRemove.length > 0) {
-              console.log(
-                `Tenant ${tenant.tenantId} has a negative or low token balance of ${tenant.remainingTokens} tokens and is on the 'FREE' plan`
+            try {
+              const instancesToRemove = await getInstancesToRemove(
+                tenant.tenantId,
+                environment
               );
-              console.log('Suspending all instances for this tenant...');
-              for (const item of instancesToRemove) {
-                console.log(` - ${item.serviceId}: ${item.instance}`);
-                if (options.apply) {
-                  await suspendInstanceForTenant(
-                    tenant.tenantId,
-                    item.serviceId,
-                    item.instance,
-                    environment
-                  );
-                  instancesSuspended++;
-                  console.log('Suspended');
+              if (instancesToRemove.length > 0) {
+                console.log(
+                  `Tenant ${tenant.tenantId} has a negative or low token balance of ${tenant.remainingTokens} tokens and is on the 'FREE' plan`
+                );
+                console.log('Suspending all instances for this tenant...');
+                for (const item of instancesToRemove) {
+                  console.log(` - ${item.serviceId}: ${item.instance}`);
+                  if (options.apply) {
+                    await suspendInstanceForTenant(
+                      tenant.tenantId,
+                      item.serviceId,
+                      item.instance,
+                      environment
+                    );
+                    instancesSuspended++;
+                    console.log('Suspended');
+                  }
                 }
               }
+            } catch (err) {
+              console.log(
+                `Failed to process tenant ${tenant.tenantId}: ${
+                  (err as Error).message
+                }`
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary

- Moves the `try/catch` inside the per-tenant loop in the `remove-exceeding-tenant-instances` admin command
- A failure for one tenant (e.g. a 500 from deploy-manager) now logs an error and continues to the next tenant instead of aborting the entire run
- The outer `try/catch` is retained for the initial `getTenantPlanMap` / `getTenantTokenCounts` calls, which are fatal if they fail

## Test plan

- [ ] Verify `npx tsc --noEmit` passes (done locally)
- [ ] Dry-run the command with `--apply` omitted against dev; confirm it iterates all tenants even if one would have thrown
- [ ] Confirm the summary line still prints after the loop completes

🤖 Generated with [Claude Code](https://claude.ai/code)