### PR TITLE
fix(cli): use deploy-manager K8s instance lookup in getInstancesToRemove

### DIFF
--- a/packages/cli/src/admin/instance.ts
+++ b/packages/cli/src/admin/instance.ts
@@ -5,7 +5,6 @@ import {
   removeInstance
 } from '@osaas/client-core';
 import { generatePat, apiKey } from './token';
-import { listSubscriptionsForTenant } from './subscription';
 
 export async function listInstancesForTenant(
   tenantId: string,
@@ -59,18 +58,22 @@ export async function suspendInstanceForTenant(
 export async function getInstancesToRemove(
   tenantId: string,
   environment: string
-) {
-  const services = await listSubscriptionsForTenant(tenantId, environment);
-  const instancesToRemove: { serviceId: string; instance: string }[] = [];
-  for (const serviceId of services) {
-    const instances = await listInstancesForTenant(
-      tenantId,
-      serviceId,
-      environment
-    );
-    instances.forEach((instance) => {
-      instancesToRemove.push({ serviceId, instance });
-    });
-  }
-  return instancesToRemove;
+): Promise<{ serviceId: string; instance: string }[]> {
+  const instancesUrl = `https://deploy.svc.${environment}.osaas.io/instances/${tenantId}`;
+  const instances = await createFetch<
+    Array<{
+      tenantId: string;
+      serviceId: string;
+      instanceName: string;
+      created: string;
+    }>
+  >(instancesUrl, {
+    headers: {
+      Authorization: `Bearer ${apiKey()}`
+    }
+  });
+  return instances.map(({ serviceId, instanceName }) => ({
+    serviceId,
+    instance: instanceName
+  }));
 }


### PR DESCRIPTION
## Summary

- Replaces the subscription-based instance discovery in `getInstancesToRemove` with a direct call to deploy-manager's `GET /instances/:tenantId` endpoint
- The deploy-manager endpoint returns all instances from K8s by tenant label, including orphaned instances that have no matching subscription in catalog-manager
- Removes the now-unused `listSubscriptionsForTenant` import from `instance.ts`

## Motivation

The `admin remove-exceeding-tenant-instances` cronjob was missing orphaned instances (instances that exist in K8s but have no catalog-manager subscription). Using deploy-manager's K8s-based lookup is both simpler and more correct.

## Test plan

- [ ] Type-check passes: `npx tsc -p packages/cli/tsconfig.json --noEmit`
- [ ] Prettier passes on the edited file
- [ ] Verify `admin remove-exceeding-tenant-instances --apply` on dev finds instances regardless of subscription state

🤖 Generated with [Claude Code](https://claude.ai/code)