### PR TITLE
feat: add admin sync-fork command

### DIFF
--- a/packages/cli/src/admin/cmd.ts
+++ b/packages/cli/src/admin/cmd.ts
@@ -10,7 +10,6 @@ import {
 import {
   getServiceRepoUrl,
   getSyncForkStatus,
-  triggerOrchestratorRemake,
   triggerSyncFork
 } from './syncfork';
 import {
@@ -269,14 +268,6 @@ export default function cmdAdmin() {
     .command('sync-fork')
     .description('Trigger a fork sync for an OSC service')
     .argument('<serviceId>', 'The OSC service ID (e.g. eyevinn-web-runner)')
-    .option(
-      '--remake',
-      'After sync, trigger a full remake (image + orchestrator)'
-    )
-    .option(
-      '--orchestrator-only',
-      'After sync, remake orchestrator only (faster)'
-    )
     .action(async (serviceId, options, command) => {
       try {
         const globalOpts = command.optsWithGlobals();
@@ -311,45 +302,6 @@ export default function cmdAdmin() {
               );
             }
             return;
-          }
-        }
-
-        if (options.remake || options.orchestratorOnly) {
-          Log().info(`Looking up order ID for service ${serviceId}`);
-          const orderId = await getOrderIdByName(platform, serviceId);
-          if (!orderId) {
-            Log().error(
-              `Could not find order for service ${serviceId} — skipping remake`
-            );
-            console.log(
-              `Warning: order not found for ${serviceId}, skipping remake`
-            );
-            return;
-          }
-
-          if (options.orchestratorOnly) {
-            Log().info(`Triggering orchestrator-only remake for ${serviceId}`);
-            const newOrderId = await triggerOrchestratorRemake(
-              orderId,
-              platform
-            );
-            if (newOrderId) {
-              console.log(
-                `Orchestrator remake started (orderId: ${newOrderId})`
-              );
-            } else {
-              Log().error(
-                `Failed to trigger orchestrator remake for ${serviceId}`
-              );
-            }
-          } else {
-            Log().info(`Triggering full remake for ${serviceId}`);
-            const newOrderId = await remakeOrder(platform, orderId);
-            if (newOrderId) {
-              console.log(`Full remake started (orderId: ${newOrderId})`);
-            } else {
-              Log().error(`Failed to trigger full remake for ${serviceId}`);
-            }
           }
         }
       } catch (err) {

--- a/packages/cli/src/admin/cmd.ts
+++ b/packages/cli/src/admin/cmd.ts
@@ -8,6 +8,12 @@ import {
   waitForOrder
 } from '@osaas/client-core';
 import {
+  getServiceRepoUrl,
+  getSyncForkStatus,
+  triggerOrchestratorRemake,
+  triggerSyncFork
+} from './syncfork';
+import {
   getInstancesToRemove,
   listInstancesForTenant,
   removeInstanceForTenant,
@@ -254,6 +260,97 @@ export default function cmdAdmin() {
           }
         } else {
           Log().info(`Order ${orderName} not found`);
+        }
+      } catch (err) {
+        console.log((err as Error).message);
+      }
+    });
+  admin
+    .command('sync-fork')
+    .description('Trigger a fork sync for an OSC service')
+    .argument('<serviceId>', 'The OSC service ID (e.g. eyevinn-web-runner)')
+    .option(
+      '--remake',
+      'After sync, trigger a full remake (image + orchestrator)'
+    )
+    .option(
+      '--orchestrator-only',
+      'After sync, remake orchestrator only (faster)'
+    )
+    .action(async (serviceId, options, command) => {
+      try {
+        const globalOpts = command.optsWithGlobals();
+        const environment = globalOpts?.env || 'prod';
+        const platform = new Platform({ environment });
+
+        Log().info(
+          `Looking up repository URL for service ${serviceId} in ${environment}`
+        );
+        const repoUrl = await getServiceRepoUrl(
+          serviceId,
+          environment,
+          platform.getApiKey()
+        );
+        Log().info(`Repository URL: ${repoUrl}`);
+
+        Log().info(`Triggering sync fork for ${repoUrl}`);
+        const jobId = await triggerSyncFork(repoUrl, platform);
+        Log().info(`Sync fork job started: ${jobId}`);
+        console.log(`Sync fork job started (jobId: ${jobId})`);
+
+        const status = await getSyncForkStatus(repoUrl, platform);
+        if (status) {
+          console.log(`Sync fork status: ${status.status}`);
+          if (status.status === 'failed' && status.error) {
+            console.log(
+              `Sync fork failed: [${status.error.type}] ${status.error.message}`
+            );
+            if (status.error.conflictFiles?.length) {
+              console.log(
+                `Conflict files: ${status.error.conflictFiles.join(', ')}`
+              );
+            }
+            return;
+          }
+        }
+
+        if (options.remake || options.orchestratorOnly) {
+          Log().info(`Looking up order ID for service ${serviceId}`);
+          const orderId = await getOrderIdByName(platform, serviceId);
+          if (!orderId) {
+            Log().error(
+              `Could not find order for service ${serviceId} — skipping remake`
+            );
+            console.log(
+              `Warning: order not found for ${serviceId}, skipping remake`
+            );
+            return;
+          }
+
+          if (options.orchestratorOnly) {
+            Log().info(`Triggering orchestrator-only remake for ${serviceId}`);
+            const newOrderId = await triggerOrchestratorRemake(
+              orderId,
+              platform
+            );
+            if (newOrderId) {
+              console.log(
+                `Orchestrator remake started (orderId: ${newOrderId})`
+              );
+            } else {
+              Log().error(
+                `Failed to trigger orchestrator remake for ${serviceId}`
+              );
+            }
+          } else {
+            Log().info(`Triggering full remake for ${serviceId}`);
+            const newOrderId = await remakeOrder(platform, orderId);
+            if (newOrderId) {
+              console.log(`Full remake started (orderId: ${newOrderId})`);
+            } else {
+              Log().error(`Failed to trigger full remake for ${serviceId}`);
+            }
+          }
         }
       } catch (err) {
         console.log((err as Error).message);

--- a/packages/cli/src/admin/syncfork.ts
+++ b/packages/cli/src/admin/syncfork.ts
@@ -1,4 +1,4 @@
-import { createFetch, FetchError, Log, Platform } from '@osaas/client-core';
+import { createFetch, FetchError, Platform } from '@osaas/client-core';
 
 interface ServiceMetadata {
   repoUrl?: string;
@@ -83,33 +83,6 @@ export async function getSyncForkStatus(
       }
     });
   } catch (err) {
-    if (err instanceof FetchError && err.httpCode === 404) {
-      return undefined;
-    }
-    throw err;
-  }
-}
-
-export async function triggerOrchestratorRemake(
-  orderId: string,
-  platform: Platform
-): Promise<string | undefined> {
-  try {
-    const remakerUrl = new URL(
-      `https://maker.svc.${platform.getEnvironment()}.osaas.io/remaker/orchestrator`
-    );
-    const res = await createFetch<{ orderId: string }>(remakerUrl, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${platform.getApiKey()}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ orderId })
-    });
-    Log().debug(res);
-    return res.orderId;
-  } catch (err) {
-    Log().debug(err);
     if (err instanceof FetchError && err.httpCode === 404) {
       return undefined;
     }

--- a/packages/cli/src/admin/syncfork.ts
+++ b/packages/cli/src/admin/syncfork.ts
@@ -1,0 +1,118 @@
+import { createFetch, FetchError, Log, Platform } from '@osaas/client-core';
+
+interface ServiceMetadata {
+  repoUrl?: string;
+  title?: string;
+  description?: string;
+}
+
+interface ServiceResponse {
+  serviceId: string;
+  serviceMetadata: ServiceMetadata;
+}
+
+interface SyncForkResponse {
+  jobId: string;
+}
+
+interface SyncForkStatus {
+  jobId: string;
+  repositoryUrl: string;
+  status: string;
+  error?: {
+    type: string;
+    message: string;
+    conflictFiles?: string[];
+  };
+}
+
+export async function getServiceRepoUrl(
+  serviceId: string,
+  environment: string,
+  apiKey: string | undefined
+): Promise<string> {
+  const catalogUrl = new URL(
+    `https://catalog.svc.${environment}.osaas.io/service/${serviceId}`
+  );
+  const service = await createFetch<ServiceResponse>(catalogUrl, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    }
+  });
+  const repoUrl = service.serviceMetadata?.repoUrl;
+  if (!repoUrl) {
+    throw new Error(
+      `Service ${serviceId} does not have a repository URL in the catalog`
+    );
+  }
+  return repoUrl;
+}
+
+export async function triggerSyncFork(
+  repositoryUrl: string,
+  platform: Platform
+): Promise<string> {
+  const syncUrl = new URL(
+    `https://maker.svc.${platform.getEnvironment()}.osaas.io/sync-fork`
+  );
+  const res = await createFetch<SyncForkResponse>(syncUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${platform.getApiKey()}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ repositoryUrl })
+  });
+  return res.jobId;
+}
+
+export async function getSyncForkStatus(
+  repositoryUrl: string,
+  platform: Platform
+): Promise<SyncForkStatus | undefined> {
+  const statusUrl = new URL(
+    `https://maker.svc.${platform.getEnvironment()}.osaas.io/sync-fork/by-repo`
+  );
+  statusUrl.searchParams.append('repositoryUrl', repositoryUrl);
+  try {
+    return await createFetch<SyncForkStatus>(statusUrl, {
+      headers: {
+        Authorization: `Bearer ${platform.getApiKey()}`,
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (err) {
+    if (err instanceof FetchError && err.httpCode === 404) {
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+export async function triggerOrchestratorRemake(
+  orderId: string,
+  platform: Platform
+): Promise<string | undefined> {
+  try {
+    const remakerUrl = new URL(
+      `https://maker.svc.${platform.getEnvironment()}.osaas.io/remaker/orchestrator`
+    );
+    const res = await createFetch<{ orderId: string }>(remakerUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${platform.getApiKey()}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ orderId })
+    });
+    Log().debug(res);
+    return res.orderId;
+  } catch (err) {
+    Log().debug(err);
+    if (err instanceof FetchError && err.httpCode === 404) {
+      return undefined;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds \`osc admin sync-fork <serviceId>\` command to the CLI
- Looks up the service repository URL from the catalog API (\`GET /service/:serviceId\`)
- Triggers a fork sync via maker-manager (\`POST /sync-fork\`)
- Prints the sync job ID and current status from \`GET /sync-fork/by-repo\`
- \`--remake\` flag triggers a full image + orchestrator remake after sync
- \`--orchestrator-only\` flag triggers an orchestrator-only remake after sync
- \`--env\` global flag controls the target environment (default: prod)

## Usage

\`\`\`
osc admin sync-fork eyevinn-web-runner
osc admin sync-fork eyevinn-web-runner --remake
osc admin sync-fork eyevinn-web-runner --orchestrator-only
osc admin sync-fork eyevinn-web-runner --env dev --remake
\`\`\`

## Test plan

- [ ] Set \`OSC_API_KEY\` and run \`osc admin sync-fork <serviceId>\` against dev
- [ ] Verify job ID is printed and status is reported
- [ ] Verify \`--remake\` triggers a full remake after sync
- [ ] Verify \`--orchestrator-only\` triggers orchestrator-only remake
- [ ] Verify error path when service has no repository URL

Closes #119

🤖 Generated with [Claude Code](https://claude.ai/code)