### PR TITLE
fix(cli): add --config-api-key to web config-to-env for secret parameter decryption

### DIFF
--- a/packages/cli/src/web/cmd.ts
+++ b/packages/cli/src/web/cmd.ts
@@ -9,11 +9,17 @@ import {
 import { createCloudfrontDistribution, publish } from '@osaas/client-web';
 import { Command } from 'commander';
 
+interface ConfigItem {
+  key: string;
+  value: string;
+  secret?: boolean;
+}
+
 interface ConfigList {
   offset: number;
   limit: number;
   total: number;
-  items: [{ key: string; value: string }];
+  items: ConfigItem[];
 }
 
 export function cmdWeb() {
@@ -193,6 +199,10 @@ export function cmdWeb() {
       '<configInstance>',
       'Name of the application configuration service instance'
     )
+    .option(
+      '--config-api-key <key>',
+      'API key for accessing secret parameters (or set CONFIG_API_KEY env var)'
+    )
     .action(async (configInstance, options, command) => {
       try {
         const globalOpts = command.optsWithGlobals();
@@ -206,10 +216,16 @@ export function cmdWeb() {
           token
         );
         if (instance) {
+          const configApiKey =
+            options.configApiKey || process.env.CONFIG_API_KEY;
           const url = new URL('/api/v1/config', instance.url);
-          const response = await fetch(url, {
-            headers: { Authorization: `Bearer ${token}` }
-          });
+          // Use the config API key for secret decryption if provided; omit the
+          // Authorization header otherwise — non-secret params still work but
+          // secrets will be masked as *** by the config service.
+          const fetchHeaders: Record<string, string> = configApiKey
+            ? { Authorization: `Bearer ${configApiKey}` }
+            : {};
+          const response = await fetch(url, { headers: fetchHeaders });
           if (!response.ok) {
             throw new Error(
               `Failed to load config from '${configInstance}': HTTP ${response.status}`
@@ -217,7 +233,9 @@ export function cmdWeb() {
           }
           const data: ConfigList = (await response.json()) as ConfigList;
           data.items.map((config) => {
-            // Single-quote values to prevent shell expansion of special characters
+            // Single-quote values to prevent shell expansion of special characters.
+            // The `secret` field is intentionally not emitted — only the resolved
+            // value (or *** if undecrypted) is written to the shell output.
             const escaped = config.value.replace(/'/g, "'\\''");
             console.log(`export ${config.key.toUpperCase()}='${escaped}'`);
           });


### PR DESCRIPTION
## Summary

Closes #123
Part of epic Eyevinn/osaas-app#3762

The `web config-to-env` command was sending the OSC service access token (a JWT) as the Authorization header when calling `GET /api/v1/config`. However, app-config-svc (PR Eyevinn/app-config-svc#9) enforces a static `CONFIG_API_KEY` bearer-token equality check for secret parameter decryption — not a JWT check. Without this fix, secret parameters silently export as the literal string `***` even when the caller provides an authorization header.

**Changes:**
- Added `ConfigItem` interface with `secret?: boolean` field (fixes the tuple-literal type bug on `ConfigList.items`)
- Added `--config-api-key <key>` option to `web config-to-env`, with `CONFIG_API_KEY` env var fallback
- When a config API key is provided, it is sent as `Authorization: Bearer <key>` for secret parameter decryption
- When no key is provided, no Authorization header is sent — non-secret parameter export still works; secrets export as `***`
- The `secret` field is intentionally not emitted in shell output

**Note for operators:** `CONFIG_API_KEY` must be distributed to runners out-of-band (deploy-time env, K8s secret). Key distribution is tracked in the parent epic Eyevinn/osaas-app#3762.

## Test plan
- [ ] `web config-to-env --config-api-key <key>` exports secret parameter values as plaintext
- [ ] `web config-to-env` (no key) exports plaintext for non-secret params, `***` for secrets
- [ ] `CONFIG_API_KEY=<key> web config-to-env` also works (env fallback)
- [ ] TypeScript compiles cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)