### PR TITLE
fix: send service token as Authorization, CONFIG_API_KEY as x-config-api-key in config-to-env

### DIFF
--- a/packages/cli/src/web/cmd.ts
+++ b/packages/cli/src/web/cmd.ts
@@ -219,12 +219,15 @@ export function cmdWeb() {
           const configApiKey =
             options.configApiKey || process.env.CONFIG_API_KEY;
           const url = new URL('/api/v1/config', instance.url);
-          // Use the config API key for secret decryption if provided; omit the
-          // Authorization header otherwise — non-secret params still work but
-          // secrets will be masked as *** by the config service.
-          const fetchHeaders: Record<string, string> = configApiKey
-            ? { Authorization: `Bearer ${configApiKey}` }
-            : {};
+          // Always send the service access token (satisfies the OSC token wall).
+          // Additionally send x-config-api-key when available — the config service
+          // uses this dedicated header to authorize secret parameter decryption.
+          const fetchHeaders: Record<string, string> = {
+            Authorization: `Bearer ${token}`
+          };
+          if (configApiKey) {
+            fetchHeaders['x-config-api-key'] = configApiKey;
+          }
           const response = await fetch(url, { headers: fetchHeaders });
           if (!response.ok) {
             throw new Error(


### PR DESCRIPTION
## Summary

- The `config-to-env` command was using `CONFIG_API_KEY` as the `Authorization: Bearer` token, which failed the OSC token wall since it is not a service access token.
- Now the service access token (from `ctx.getServiceAccessToken('eyevinn-app-config-svc')`) is always sent as `Authorization`, satisfying the token wall.
- When `CONFIG_API_KEY` (or `--config-api-key`) is provided, it is sent in the new dedicated `x-config-api-key` header that `app-config-svc` uses to authorize secret parameter decryption.

## Changes

- `packages/cli/src/web/cmd.ts`: updated `fetchHeaders` construction in the `config-to-env` action.

## References

- Closes EyevinnOSC/client-ts#123
- Part of epic Eyevinn/osaas-app#3762

## Test plan

- [ ] `osc web config-to-env <instance>` without `CONFIG_API_KEY` returns non-secret config values (token wall satisfied, secrets masked as `***`)
- [ ] `osc web config-to-env <instance> --config-api-key <key>` returns decrypted secret values
- [ ] `npx tsc --noEmit` passes on `packages/cli` (no new errors in `src/web/cmd.ts`)
- [ ] `npx prettier --check src/web/cmd.ts` passes
- [ ] `npx eslint src/web/cmd.ts` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>