### PR TITLE
fix(cli): paginate config-to-env to fetch all entries

### DIFF
--- a/packages/cli/src/web/cmd.ts
+++ b/packages/cli/src/web/cmd.ts
@@ -229,14 +229,13 @@ export function cmdWeb() {
           }
 
           const pageLimit = 100;
-          let offset = 0;
-          let hasMore = true;
+          let cursor = 0;
           const allItems: ConfigItem[] = [];
 
-          while (hasMore) {
+          do {
             const url = new URL('/api/v1/config', instance.url);
             url.searchParams.set('limit', String(pageLimit));
-            url.searchParams.set('offset', String(offset));
+            url.searchParams.set('offset', String(cursor));
 
             const response = await fetch(url, { headers: fetchHeaders });
             if (!response.ok) {
@@ -246,9 +245,8 @@ export function cmdWeb() {
             }
             const page: ConfigList = (await response.json()) as ConfigList;
             allItems.push(...page.items);
-            offset += page.items.length;
-            hasMore = offset < page.total;
-          }
+            cursor = page.offset;
+          } while (cursor !== 0);
 
           allItems.map((config) => {
             // Single-quote values to prevent shell expansion of special characters.

--- a/packages/cli/src/web/cmd.ts
+++ b/packages/cli/src/web/cmd.ts
@@ -218,7 +218,6 @@ export function cmdWeb() {
         if (instance) {
           const configApiKey =
             options.configApiKey || process.env.CONFIG_API_KEY;
-          const url = new URL('/api/v1/config', instance.url);
           // Always send the service access token (satisfies the OSC token wall).
           // Additionally send x-config-api-key when available — the config service
           // uses this dedicated header to authorize secret parameter decryption.
@@ -228,14 +227,30 @@ export function cmdWeb() {
           if (configApiKey) {
             fetchHeaders['x-config-api-key'] = configApiKey;
           }
-          const response = await fetch(url, { headers: fetchHeaders });
-          if (!response.ok) {
-            throw new Error(
-              `Failed to load config from '${configInstance}': HTTP ${response.status}`
-            );
+
+          const pageLimit = 100;
+          let offset = 0;
+          let hasMore = true;
+          const allItems: ConfigItem[] = [];
+
+          while (hasMore) {
+            const url = new URL('/api/v1/config', instance.url);
+            url.searchParams.set('limit', String(pageLimit));
+            url.searchParams.set('offset', String(offset));
+
+            const response = await fetch(url, { headers: fetchHeaders });
+            if (!response.ok) {
+              throw new Error(
+                `Failed to load config from '${configInstance}': HTTP ${response.status}`
+              );
+            }
+            const page: ConfigList = (await response.json()) as ConfigList;
+            allItems.push(...page.items);
+            offset += page.items.length;
+            hasMore = offset < page.total;
           }
-          const data: ConfigList = (await response.json()) as ConfigList;
-          data.items.map((config) => {
+
+          allItems.map((config) => {
             // Single-quote values to prevent shell expansion of special characters.
             // The `secret` field is intentionally not emitted — only the resolved
             // value (or *** if undecrypted) is written to the shell output.


### PR DESCRIPTION
## Summary
- Fixes silent truncation in `osc web config-to-env` when config service has more than 20 entries
- Replaces single-page fetch with a pagination loop using `offset`/`limit`/`total` from the API response
- Uses `limit=100` to minimize round trips
- Exits with non-zero code if any page fetch fails

Fixes #126

🤖 Generated with [Claude Code](https://claude.ai/code)