### PR TITLE
fix(core): accept SuccessCriteriaMet as terminal success status in waitForJobToComplete (#128)

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,7 +1,16 @@
 {
   "plugins": ["plugins/markdown"],
   "source": {
-    "include": ["readme.md", "packages/core/", "packages/services/", "packages/transcode", "packages/web", "packages/db", "packages/intercom", "packages/mcp"],
+    "include": [
+      "readme.md",
+      "packages/core/",
+      "packages/services/",
+      "packages/transcode",
+      "packages/web",
+      "packages/db",
+      "packages/intercom",
+      "packages/mcp"
+    ],
     "includePattern": "\\.js$",
     "excludePattern": "(node_modules/|docs)"
   },

--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -1,0 +1,68 @@
+import { Context } from './context';
+import { waitForJobToComplete } from './job';
+
+// Mock the core module so getJob returns controllable status values
+jest.mock('./core', () => ({
+  getService: jest.fn().mockResolvedValue({ serviceType: 'job' }),
+  getInstance: jest.fn(),
+  createInstance: jest.fn(),
+  removeInstance: jest.fn(),
+  listInstances: jest.fn()
+}));
+
+import { getInstance } from './core';
+
+const mockGetInstance = getInstance as jest.MockedFunction<typeof getInstance>;
+
+describe('waitForJobToComplete', () => {
+  const ctx = new Context({ personalAccessToken: 'dummy' });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('resolves when job status is Complete', async () => {
+    mockGetInstance.mockResolvedValue({ status: 'Complete' });
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token')
+    ).resolves.toBeUndefined();
+    expect(mockGetInstance).toHaveBeenCalledTimes(1);
+  });
+
+  test('resolves when job status is SuccessCriteriaMet', async () => {
+    mockGetInstance.mockResolvedValue({ status: 'SuccessCriteriaMet' });
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token')
+    ).resolves.toBeUndefined();
+    expect(mockGetInstance).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws when job status is Failed', async () => {
+    mockGetInstance.mockResolvedValue({ status: 'Failed' });
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token')
+    ).rejects.toThrow("Job 'myjob' failed with status: Failed");
+    expect(mockGetInstance).toHaveBeenCalledTimes(1);
+  });
+
+  test('polls until job reaches terminal status', async () => {
+    mockGetInstance
+      .mockResolvedValueOnce({ status: 'Running' })
+      .mockResolvedValueOnce({ status: 'Running' })
+      .mockResolvedValueOnce({ status: 'SuccessCriteriaMet' });
+
+    // Speed up the delay for tests
+    jest.useFakeTimers();
+    const promise = waitForJobToComplete(
+      ctx,
+      'eyevinn-test-job',
+      'myjob',
+      'token'
+    );
+    // Advance timers past each 1s delay
+    await jest.runAllTimersAsync();
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockGetInstance).toHaveBeenCalledTimes(3);
+    jest.useRealTimers();
+  });
+});

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -124,6 +124,10 @@ export async function listJobs(
  * @param {string} serviceId - Service identifier. The service identifier is {github-organization}-{github-repo}
  * @param {string} name - Name of service job to wait for
  * @param {string} token - Service access token
+ * @throws {Error} If the job reaches a terminal failure state ('Failed')
+ *
+ * Terminal success statuses: 'Complete', 'SuccessCriteriaMet'
+ * Terminal failure statuses: 'Failed'
  */
 export async function waitForJobToComplete(
   context: Context,
@@ -133,8 +137,11 @@ export async function waitForJobToComplete(
 ) {
   for (const _ of Array(MAX_ITER)) {
     const job = await getJob(context, serviceId, name, token);
-    if (job.status === 'Complete') {
+    if (job.status === 'Complete' || job.status === 'SuccessCriteriaMet') {
       break;
+    }
+    if (job.status === 'Failed') {
+      throw new Error(`Job '${name}' failed with status: ${job.status}`);
     }
     await delay(1000);
   }

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ const ctx = new Context();
 It will read the Personal Access Token from the environment variable `OSC_ACCESS_TOKEN`. To override the default configuration and read the token from another environment variable, here called `MY_TOKEN`, and connect to the development environment you setup a context as below.
 
 ```javascript
-const ctx = new Context({ personalAccessToken: process.env.MY_TOKEN })
+const ctx = new Context({ personalAccessToken: process.env.MY_TOKEN });
 ```
 
 To create, list or remove a service instance you then need to obtain a temporary Service Access Token (SAT) first. This is achieved with the `getServiceAccessToken()`. For example to get an SAT for the service `eyevinn-chaos-stream-proxy` you write.
@@ -103,7 +103,13 @@ Use the `-y` flag to skip the confirmation prompt.
 #### SDK
 
 ```javascript
-import { Context, listMyApps, createMyApp, getMyApp, removeMyApp } from '@osaas/client-core';
+import {
+  Context,
+  listMyApps,
+  createMyApp,
+  getMyApp,
+  removeMyApp
+} from '@osaas/client-core';
 
 const ctx = new Context();
 


### PR DESCRIPTION
## Summary

- Adds `'SuccessCriteriaMet'` as an accepted terminal success status alongside `'Complete'` in `waitForJobToComplete`
- Adds early exit with error throw when job status is `'Failed'` to avoid burning all 1000 poll iterations on failed jobs
- Documents accepted terminal statuses in JSDoc
- Adds unit tests covering `Complete`, `SuccessCriteriaMet`, `Failed`, and polling scenarios

Closes #128

## Root cause

`packages/core/src/job.ts` line 136 checked only `job.status === 'Complete'`, but the underlying service returns `'SuccessCriteriaMet'` as the terminal success status. This caused the function to poll all 1000 iterations (MAX_ITER = 1000) even for successfully completed jobs.

## Test plan

- [ ] Verify `waitForJobToComplete` resolves immediately when status is `'SuccessCriteriaMet'`
- [ ] Verify `waitForJobToComplete` still resolves for `'Complete'` (backwards compatibility)
- [ ] Verify `waitForJobToComplete` throws for `'Failed'` status
- [ ] Run `npm test` in `packages/core` to confirm unit tests pass

## Lessons

`'SuccessCriteriaMet'` is the actual terminal success status returned by OSC services, not `'Complete'`. When a polling function seems to timeout on successful jobs, check whether the status string matches what the service actually returns — the string values are not standardized across all service types (e.g. `waitForEncoreJobToComplete` in `packages/transcode/src/util.ts` uses `'SUCCESSFUL'` for a different API).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>