### PR TITLE
fix(core): return RemoveInstanceResult from removeInstance, treat 404 as alreadyAbsent

### DIFF
--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -3,7 +3,10 @@ import { createInstance, isValidInstanceName, removeInstance } from './core';
 import { InvalidName } from './errors';
 import { createFetch, FetchError } from './fetch';
 
-jest.mock('./fetch');
+jest.mock('./fetch', () => ({
+  ...jest.requireActual('./fetch'),
+  createFetch: jest.fn()
+}));
 
 describe('Core functionalities', () => {
   afterAll(() => {

--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -1,7 +1,7 @@
 import { Context } from './context';
-import { createInstance, isValidInstanceName } from './core';
+import { createInstance, isValidInstanceName, removeInstance } from './core';
 import { InvalidName } from './errors';
-import { createFetch } from './fetch';
+import { createFetch, FetchError } from './fetch';
 
 jest.mock('./fetch');
 
@@ -41,5 +41,68 @@ describe('Core functionalities', () => {
       )
     ).rejects.not.toThrow(new InvalidName('myinstance'));
     expect(createFetch).toHaveBeenCalled();
+  });
+});
+
+describe('removeInstance', () => {
+  const mockCreateFetch = createFetch as jest.MockedFunction<
+    typeof createFetch
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const ctx = new Context({ personalAccessToken: 'dummy' });
+
+  test("returns 'success' when the DELETE call resolves", async () => {
+    // First call: getService (catalog subscription list)
+    mockCreateFetch.mockResolvedValueOnce([
+      { serviceId: 'eyevinn-test-adserver', apiUrl: 'https://api.example.com' }
+    ]);
+    // Second call: the DELETE itself
+    mockCreateFetch.mockResolvedValueOnce(undefined);
+
+    const result = await removeInstance(
+      ctx,
+      'eyevinn-test-adserver',
+      'myinstance',
+      'my-token'
+    );
+    expect(result).toBe('success');
+  });
+
+  test("returns 'alreadyAbsent' when the DELETE responds with 404", async () => {
+    // First call: getService
+    mockCreateFetch.mockResolvedValueOnce([
+      { serviceId: 'eyevinn-test-adserver', apiUrl: 'https://api.example.com' }
+    ]);
+    // Second call: DELETE throws FetchError 404
+    mockCreateFetch.mockRejectedValueOnce(
+      new FetchError({ message: 'Not Found', httpCode: 404 })
+    );
+
+    const result = await removeInstance(
+      ctx,
+      'eyevinn-test-adserver',
+      'myinstance',
+      'my-token'
+    );
+    expect(result).toBe('alreadyAbsent');
+  });
+
+  test('rethrows non-404 FetchErrors', async () => {
+    // First call: getService
+    mockCreateFetch.mockResolvedValueOnce([
+      { serviceId: 'eyevinn-test-adserver', apiUrl: 'https://api.example.com' }
+    ]);
+    // Second call: DELETE throws FetchError 500
+    mockCreateFetch.mockRejectedValueOnce(
+      new FetchError({ message: 'Internal Server Error', httpCode: 500 })
+    );
+
+    await expect(
+      removeInstance(ctx, 'eyevinn-test-adserver', 'myinstance', 'my-token')
+    ).rejects.toThrow(FetchError);
   });
 });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -112,34 +112,50 @@ export async function createInstance(
 }
 
 /**
+ * Distinguishes a successful deletion from an instance that was already absent.
+ * Callers that do not inspect the return value are unaffected by the type change.
+ */
+export type RemoveInstanceResult = 'success' | 'alreadyAbsent';
+
+/**
  * Remove an instance of a service in Open Source Cloud
  * @memberof module:@osaas/client-core
  * @param {Context} context - Open Source Cloud configuration context
  * @param {string} serviceId - The service identifier
  * @param {string} name - The name of the service instance to remove
  * @param {string} token - Service access token
+ * @returns {RemoveInstanceResult} - 'success' if the instance was deleted, 'alreadyAbsent' if it did not exist
  * @example
  * import { Context, removeInstance } from '@osaas/client-core';
  * const ctx = new Context();
  * const sat = await ctx.getServiceAccessToken('eyevinn-test-adserver');
- * await removeInstance(ctx, 'eyevinn-test-adserver', 'my-instance', sat);
+ * const result = await removeInstance(ctx, 'eyevinn-test-adserver', 'my-instance', sat);
+ * // result === 'success' | 'alreadyAbsent'
  */
 export async function removeInstance(
   context: Context,
   serviceId: string,
   name: string,
   token: string
-) {
+): Promise<RemoveInstanceResult> {
   const service = await getService(context, serviceId);
   const instanceUrl = new URL(service.apiUrl + '/' + name);
 
-  await createFetch<any>(instanceUrl, {
-    method: 'DELETE',
-    headers: {
-      'x-jwt': `Bearer ${token}`,
-      'Content-Type': 'application/json'
+  try {
+    await createFetch<any>(instanceUrl, {
+      method: 'DELETE',
+      headers: {
+        'x-jwt': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+    return 'success';
+  } catch (err) {
+    if (err instanceof FetchError && err.httpCode === 404) {
+      return 'alreadyAbsent';
     }
-  });
+    throw err;
+  }
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { Platform } from './platform';
 export {
   createInstance,
   removeInstance,
+  RemoveInstanceResult,
   getInstance,
   listInstances,
   getPortsForInstance,


### PR DESCRIPTION
## Summary
- Adds `RemoveInstanceResult = 'success' | 'alreadyAbsent'` type to `packages/core/src/core.ts`
- `removeInstance()` now catches `FetchError` with `httpCode === 404` and returns `'alreadyAbsent'` instead of throwing
- Exports `RemoveInstanceResult` from `packages/core/src/index.ts`
- Adds unit tests covering both branches and non-404 error rethrow

Backwards compatible: the return type widens from `void` to `RemoveInstanceResult`, which is a non-breaking change for callers that discard the return value.

Closes Eyevinn/osaas-deploy-manager#884

## Lessons
The `FetchError` class in `packages/core/src/fetch.ts` carries an `httpCode` field — use `err instanceof FetchError && err.httpCode === 404` as the guard, not string-matching on the error message. The 170+ generated service wrappers in `packages/services/src/generated/` call `removeInstance` but discard the result, so they remain type-safe after the return type change. The monorepo-wide `npx tsc --noEmit` produces 245 pre-existing "Cannot find module" errors from inter-package references that require built artifacts; run `npx tsc --noEmit -p packages/core/tsconfig.json` to verify the core package cleanly.

## Test plan
- [ ] All CI checks pass
- [ ] Unit tests cover: success → 'success', 404 → 'alreadyAbsent', 500 → throws

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>