### PR TITLE
feat(core): add timeout, FailureTarget handling, and job return to waitForJobToComplete

### DIFF
--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -19,21 +19,32 @@ describe('waitForJobToComplete', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   test('resolves when job status is Complete', async () => {
-    mockGetInstance.mockResolvedValue({ status: 'Complete' });
-    await expect(
-      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token')
-    ).resolves.toBeUndefined();
+    const completedJob = { name: 'myjob', status: 'Complete' };
+    mockGetInstance.mockResolvedValue(completedJob);
+    const result = await waitForJobToComplete(
+      ctx,
+      'eyevinn-test-job',
+      'myjob',
+      'token'
+    );
+    expect(result).toEqual(completedJob);
     expect(mockGetInstance).toHaveBeenCalledTimes(1);
   });
 
   test('resolves when job status is SuccessCriteriaMet', async () => {
-    mockGetInstance.mockResolvedValue({ status: 'SuccessCriteriaMet' });
-    await expect(
-      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token')
-    ).resolves.toBeUndefined();
+    const completedJob = { name: 'myjob', status: 'SuccessCriteriaMet' };
+    mockGetInstance.mockResolvedValue(completedJob);
+    const result = await waitForJobToComplete(
+      ctx,
+      'eyevinn-test-job',
+      'myjob',
+      'token'
+    );
+    expect(result).toEqual(completedJob);
     expect(mockGetInstance).toHaveBeenCalledTimes(1);
   });
 
@@ -45,13 +56,21 @@ describe('waitForJobToComplete', () => {
     expect(mockGetInstance).toHaveBeenCalledTimes(1);
   });
 
+  test('throws when job status is FailureTarget', async () => {
+    mockGetInstance.mockResolvedValue({ status: 'FailureTarget' });
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token')
+    ).rejects.toThrow("Job 'myjob' failed with status: FailureTarget");
+    expect(mockGetInstance).toHaveBeenCalledTimes(1);
+  });
+
   test('polls until job reaches terminal status', async () => {
+    const completedJob = { name: 'myjob', status: 'SuccessCriteriaMet' };
     mockGetInstance
       .mockResolvedValueOnce({ status: 'Running' })
       .mockResolvedValueOnce({ status: 'Running' })
-      .mockResolvedValueOnce({ status: 'SuccessCriteriaMet' });
+      .mockResolvedValueOnce(completedJob);
 
-    // Speed up the delay for tests
     jest.useFakeTimers();
     const promise = waitForJobToComplete(
       ctx,
@@ -59,10 +78,56 @@ describe('waitForJobToComplete', () => {
       'myjob',
       'token'
     );
-    // Advance timers past each 1s delay
     await jest.runAllTimersAsync();
-    await expect(promise).resolves.toBeUndefined();
+    const result = await promise;
+    expect(result).toEqual(completedJob);
     expect(mockGetInstance).toHaveBeenCalledTimes(3);
-    jest.useRealTimers();
+  });
+
+  test('throws on timeout when timeoutMs is exceeded', async () => {
+    // Job never completes — always returns Running
+    mockGetInstance.mockResolvedValue({ status: 'Running' });
+
+    jest.useFakeTimers();
+    const promise = waitForJobToComplete(
+      ctx,
+      'eyevinn-test-job',
+      'myjob',
+      'token',
+      { timeoutMs: 5000 }
+    );
+    // Advance time past the timeout
+    jest.advanceTimersByTime(6000);
+    await expect(promise).rejects.toThrow("Job 'myjob' timed out after 5000ms");
+  });
+
+  test('backwards compatible: no options parameter works as before', async () => {
+    const completedJob = { name: 'myjob', status: 'Complete' };
+    mockGetInstance.mockResolvedValue(completedJob);
+    // Called without options — should still resolve
+    const result = await waitForJobToComplete(
+      ctx,
+      'eyevinn-test-job',
+      'myjob',
+      'token'
+    );
+    expect(result).toEqual(completedJob);
+  });
+
+  test('returns the completed job object with all fields', async () => {
+    const completedJob = {
+      name: 'myjob',
+      status: 'Complete',
+      output: 's3://bucket/result.mp4'
+    };
+    mockGetInstance.mockResolvedValue(completedJob);
+    const result = await waitForJobToComplete(
+      ctx,
+      'eyevinn-test-job',
+      'myjob',
+      'token'
+    );
+    expect(result).toEqual(completedJob);
+    expect(result.output).toBe('s3://bucket/result.mp4');
   });
 });

--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -96,10 +96,16 @@ describe('waitForJobToComplete', () => {
       'token',
       { timeoutMs: 5000 }
     );
-    // Advance time past the timeout
+    // Flush microtasks to advance through getService + getInstance + return-await chain
+    // so the loop reaches await delay(1000) before we advance the clock
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Advance fake clock 6000ms: fires delay timer AND makes Date.now() = 6000
     jest.advanceTimersByTime(6000);
+    // Loop continues → deadline check: 6000 >= 5000 → throws
     await expect(promise).rejects.toThrow("Job 'myjob' timed out after 5000ms");
-  });
+  }, 10000);
 
   test('backwards compatible: no options parameter works as before', async () => {
     const completedJob = { name: 'myjob', status: 'Complete' };

--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -85,27 +85,24 @@ describe('waitForJobToComplete', () => {
   });
 
   test('throws on timeout when timeoutMs is exceeded', async () => {
-    // Job never completes — always returns Running
     mockGetInstance.mockResolvedValue({ status: 'Running' });
 
-    jest.useFakeTimers();
-    const promise = waitForJobToComplete(
-      ctx,
-      'eyevinn-test-job',
-      'myjob',
-      'token',
-      { timeoutMs: 5000 }
-    );
-    // Flush microtasks to advance through getService + getInstance + return-await chain
-    // so the loop reaches await delay(1000) before we advance the clock
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-    // Advance fake clock 6000ms: fires delay timer AND makes Date.now() = 6000
-    jest.advanceTimersByTime(6000);
-    // Loop continues → deadline check: 6000 >= 5000 → throws
-    await expect(promise).rejects.toThrow("Job 'myjob' timed out after 5000ms");
-  }, 10000);
+    // Spy on Date.now: first call sets the deadline, second call (the
+    // per-iteration check) returns a value well past it — no timers needed.
+    const base = 1_000_000;
+    let calls = 0;
+    const dateSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => (calls++ === 0 ? base : base + 10_000));
+
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-test-job', 'myjob', 'token', {
+        timeoutMs: 5000
+      })
+    ).rejects.toThrow("Job 'myjob' timed out after 5000ms");
+
+    dateSpy.mockRestore();
+  });
 
   test('backwards compatible: no options parameter works as before', async () => {
     const completedJob = { name: 'myjob', status: 'Complete' };

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -118,29 +118,54 @@ export async function listJobs(
 }
 
 /**
+ * Options for waitForJobToComplete
+ * @memberof module:@osaas/client-core
+ * @typedef {Object} WaitForJobOptions
+ * @property {number} [timeoutMs] - Maximum time in milliseconds to wait for the job to complete.
+ *   When omitted the function polls up to MAX_ITER (1000) iterations (~16 min).
+ *   When set, the function throws if the wall-clock time exceeds this value.
+ */
+export interface WaitForJobOptions {
+  timeoutMs?: number;
+}
+
+/**
  * Wait for a service job to complete
  * @memberof module:@osaas/client-core
  * @param {Context} context - Open Source Cloud configuration context
  * @param {string} serviceId - Service identifier. The service identifier is {github-organization}-{github-repo}
  * @param {string} name - Name of service job to wait for
  * @param {string} token - Service access token
- * @throws {Error} If the job reaches a terminal failure state ('Failed')
+ * @param {WaitForJobOptions} [options] - Optional settings
+ * @param {number} [options.timeoutMs] - Wall-clock timeout in milliseconds; throws if exceeded
+ * @returns {Promise<any>} - The completed job object
+ * @throws {Error} If the job reaches a terminal failure state ('Failed' or 'FailureTarget')
+ * @throws {Error} If timeoutMs is set and the job does not complete within the given time
  *
  * Terminal success statuses: 'Complete', 'SuccessCriteriaMet'
- * Terminal failure statuses: 'Failed'
+ * Terminal failure statuses: 'Failed', 'FailureTarget'
  */
 export async function waitForJobToComplete(
   context: Context,
   serviceId: string,
   name: string,
-  token: string
-) {
+  token: string,
+  options?: WaitForJobOptions
+): Promise<any> {
+  const deadline =
+    options?.timeoutMs !== undefined
+      ? Date.now() + options.timeoutMs
+      : undefined;
+
   for (const _ of Array(MAX_ITER)) {
+    if (deadline !== undefined && Date.now() >= deadline) {
+      throw new Error(`Job '${name}' timed out after ${options!.timeoutMs}ms`);
+    }
     const job = await getJob(context, serviceId, name, token);
     if (job.status === 'Complete' || job.status === 'SuccessCriteriaMet') {
-      break;
+      return job;
     }
-    if (job.status === 'Failed') {
+    if (job.status === 'Failed' || job.status === 'FailureTarget') {
       throw new Error(`Job '${name}' failed with status: ${job.status}`);
     }
     await delay(1000);

--- a/packages/transcode/src/index.ts
+++ b/packages/transcode/src/index.ts
@@ -14,3 +14,5 @@ export {
 export { SubtitlingPool } from './subtitling';
 export { createVodPipeline, removeVodPipeline, createVod } from './vodpipeline';
 export { transcode, getTranscodeJob, listTranscodeJobs } from './transcode';
+export { probeFile } from './probe';
+export type { ProbeResult } from './probe';

--- a/packages/transcode/src/probe.ts
+++ b/packages/transcode/src/probe.ts
@@ -1,0 +1,68 @@
+import { Context, Log } from '@osaas/client-core';
+import {
+  createEyevinnFunctionProbeInstance,
+  removeEyevinnFunctionProbeInstance
+} from '@osaas/client-services';
+
+/**
+ * Probe result from eyevinn-function-probe
+ *
+ * @memberof module:@osaas/client-transcode
+ * @typedef {Object} ProbeResult
+ * @property {any} format - Container format information
+ * @property {any[]} streams - Audio and video stream details
+ */
+export interface ProbeResult {
+  format: any;
+  streams: any[];
+}
+
+/**
+ * Probe a media file or stream and return its metadata
+ *
+ * Creates a temporary eyevinn-function-probe instance, fetches media info for
+ * the given URL, then removes the instance. The instance name is derived from a
+ * short random suffix to avoid collisions.
+ *
+ * @async
+ * @memberof module:@osaas/client-transcode
+ * @param {Context} ctx - Open Source Cloud configuration context
+ * @param {string} inputUrl - URL of the media file or stream to probe (HTTP/HTTPS or S3)
+ * @returns {ProbeResult} - Probe result containing format and stream metadata
+ * @example
+ * import { Context } from '@osaas/client-core';
+ * import { probeFile } from '@osaas/client-transcode';
+ *
+ * const ctx = new Context();
+ * const info = await probeFile(ctx, 'https://example.com/video.mp4');
+ * console.log(info.format.duration);
+ */
+export async function probeFile(
+  ctx: Context,
+  inputUrl: string
+): Promise<ProbeResult> {
+  const instanceName = `probe-${Math.random().toString(36).substring(2, 8)}`;
+  Log().debug(`Creating probe instance ${instanceName} for ${inputUrl}`);
+
+  const instance = await createEyevinnFunctionProbeInstance(ctx, {
+    name: instanceName
+  });
+
+  try {
+    const probeUrl = new URL('/probe', instance.url);
+    probeUrl.searchParams.set('url', inputUrl);
+
+    const response = await fetch(probeUrl.toString());
+    if (!response.ok) {
+      throw new Error(
+        `Probe request failed with status ${response.status}: ${response.statusText}`
+      );
+    }
+    const result = (await response.json()) as ProbeResult;
+    Log().debug(`Probe complete for ${inputUrl}`);
+    return result;
+  } finally {
+    await removeEyevinnFunctionProbeInstance(ctx, instanceName);
+    Log().debug(`Removed probe instance ${instanceName}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds optional `options?: { timeoutMs?: number }` to `waitForJobToComplete` — throws on timeout
- Adds `'FailureTarget'` to rejection status list alongside `'Failed'`
- Changes return from `Promise<void>` to `Promise<any>` — returns completed job object
- Adds `probeFile(ctx, inputUrl)` helper in `packages/transcode/src/probe.ts` using `eyevinn-function-probe`
- Adds unit tests covering timeout, FailureTarget rejection, return value, and backwards compatibility

Note: `eyevinn-ffmpeg-s3.ts` service generation is deferred — catalog OpenAPI spec requires a running instance.

Closes Eyevinn/osaas-deploy-manager#883

## Lessons
PR #129 already added `'Failed'` rejection and `'SuccessCriteriaMet'` success handling. The remaining gaps were `'FailureTarget'` (K8s job failure mode) and the return value. The `timeoutMs` option uses `Date.now()` comparison at each iteration start — no additional timers needed, fits naturally into the existing polling loop.

## Test plan
- [ ] All CI checks pass
- [ ] Unit tests cover timeout, FailureTarget, return value, backwards compat

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>