### PR TITLE
docs(transcode): document Encore callback payload and EncorePackager queue contract (#134)

### DIFF
--- a/packages/transcode/.gitignore
+++ b/packages/transcode/.gitignore
@@ -1,0 +1,2 @@
+# Allow the docs/ directory in this package (root .gitignore excludes docs/ for jsdoc output)
+!docs/

--- a/packages/transcode/docs/encore-callback.md
+++ b/packages/transcode/docs/encore-callback.md
@@ -1,0 +1,45 @@
+# Encore Callback Payload
+
+## Overview
+
+The `progressCallbackUri` field on an Encore job points to the `POST /encoreCallback` endpoint exposed by an `encore-callback-listener` instance. Encore calls this endpoint on every job status transition.
+
+## Callback Payload
+
+Derived from `encore-callback-listener/src/encoreCallbackApi.ts`:
+
+```typescript
+interface JobProgress {
+  jobId: string;
+  externalId?: string; // optional — set on the job at creation
+  progress: number; // 0–100
+  status: string; // see status enum below
+}
+```
+
+## Status Enum
+
+`NEW | QUEUED | IN_PROGRESS | SUCCESSFUL | FAILED | CANCELLED`
+
+## When It Fires
+
+Encore calls `progressCallbackUri` on every status change. The callback listener only acts on `SUCCESSFUL` (case-insensitive comparison: `status.toUpperCase() === 'SUCCESSFUL'`).
+
+## What the Listener Does
+
+- On `SUCCESSFUL`: publishes a queue message to Redis (see [encore-packager.md](./encore-packager.md))
+- All other statuses: logged but otherwise dropped — nothing is enqueued
+
+**Note**: The SVT Encore upstream docs at svt.github.io/encore-doc do not document the callback payload shape. The authoritative source is `encore-callback-listener/src/encoreCallbackApi.ts` (TypeBox schema).
+
+**Note**: The `progress` field (0–100) is present in the callback payload but not used by the listener logic. It is informational only.
+
+**Note**: `externalId` is optional — it is set at job creation time. If the caller omits it, the callback will not carry it.
+
+## Test Example
+
+```bash
+curl -X POST https://<listener-url>/encoreCallback \
+  -H 'Content-Type: application/json' \
+  -d '{"jobId":"abc123","externalId":"myjob-xyz","progress":100,"status":"SUCCESSFUL"}'
+```

--- a/packages/transcode/docs/encore-packager.md
+++ b/packages/transcode/docs/encore-packager.md
@@ -30,7 +30,7 @@ The queue is a **sorted set** (not a list). Pop command:
 BZPOPMIN <queueName> <timeout-seconds>
 ```
 
-The queue name defaults to `package` in the VOD pipeline and is configurable via the `RedisQueue` option on both `EncorePackager` and `EncoreTransfer`.
+The queue name is configurable via the `RedisQueue` option on both `EncorePackager` and `EncoreTransfer`. The code-level default is `packaging-queue`; the OSC platform configures `REDIS_QUEUE=package` for the VOD pipeline deployment.
 
 > **Important**: Consumers using `BLPOP` will silently never receive messages because `BLPOP` operates on lists, not sorted sets.
 

--- a/packages/transcode/docs/encore-packager.md
+++ b/packages/transcode/docs/encore-packager.md
@@ -1,0 +1,79 @@
+# EncorePackager Queue Contract
+
+## Overview
+
+`EncorePackager` (and `EncoreTransfer`) are Redis queue consumers. They pop messages from a Redis **sorted set** using `BZPOPMIN` (blocking sorted-set pop). The sort score is `Date.now()` (epoch ms), so messages are processed in insertion order.
+
+## Queue Message Format
+
+Derived from `encore-packager/src/redisListener.ts` (TypeBox schema):
+
+```typescript
+interface QueueMessage {
+  jobId: string; // Encore job ID (UUID)
+  url: string; // Full URL to the Encore job resource
+  // e.g. https://<encore-url>/encoreJobs/<jobId>
+}
+```
+
+This is exactly what `encore-callback-listener` pushes on `SUCCESSFUL`:
+
+```typescript
+{ jobId: jobProgress.jobId, url: `${encoreUrl}/encoreJobs/${jobProgress.jobId}` }
+```
+
+## Redis Data Structure
+
+The queue is a **sorted set** (not a list). Pop command:
+
+```
+BZPOPMIN <queueName> <timeout-seconds>
+```
+
+The queue name defaults to `package` in the VOD pipeline and is configurable via the `RedisQueue` option on both `EncorePackager` and `EncoreTransfer`.
+
+> **Important**: Consumers using `BLPOP` will silently never receive messages because `BLPOP` operates on lists, not sorted sets.
+
+## What EncorePackager Does
+
+After popping a message, `EncorePackager`:
+
+1. Fetches the full Encore job from `url`
+2. Validates `status === 'SUCCESSFUL'`
+3. Reads the `output[]` array (VideoFile / AudioFile entries)
+4. Runs Shaka Packager (S3) to produce HLS/DASH output
+
+The `EncoreJob` shape it expects at that URL:
+
+```typescript
+interface EncoreJob {
+  id: string;
+  externalId?: string;
+  status: string; // must be 'SUCCESSFUL'
+  inputs: { uri: string }[];
+  output?: {
+    type: string; // 'VideoFile' | 'AudioFile'
+    format: string;
+    file: string;
+    fileSize: number;
+    overallBitrate: number;
+    videoStreams?: { codec: string; bitrate: number }[];
+    audioStreams?: { codec: string; bitrate: number; channels: number }[];
+  }[];
+}
+```
+
+## Building an Alternative Consumer
+
+Any process that:
+
+1. Connects to the same Redis instance
+2. Issues `BZPOPMIN <queueName>` in a loop
+3. Parses the JSON `QueueMessage`
+4. Fetches `url` to get the full job detail
+
+...is a valid alternative consumer. The sorted-set pop is destructive (first popper wins), so only one consumer processes each message.
+
+## Concurrency
+
+`EncorePackager` tracks in-flight jobs and skips popping when `noProcessing >= concurrency` (default: 1). Alternative consumers should implement similar back-pressure.


### PR DESCRIPTION
## Summary

- Add `packages/transcode/docs/encore-callback.md`: documents the `POST /encoreCallback` payload shape, status enum, when the listener fires, and what it does on `SUCCESSFUL` status.
- Add `packages/transcode/docs/encore-packager.md`: documents the Redis sorted-set queue contract (`BZPOPMIN`), the `QueueMessage` format, what `EncorePackager` does after popping a message, and guidance for building alternative consumers.
- Add `packages/transcode/.gitignore` to negate the root-level `docs/` exclusion (root gitignore blocks all `docs/` dirs for jsdoc output; package-level negation allows handwritten docs here).

Closes #134

## Lessons

The root `.gitignore` entry `docs/` applies to any directory named `docs/` at any depth in the repo (not just the root jsdoc output dir), so a package-level `.gitignore` negation (`!docs/`) was needed to track the new handwritten docs directory — this is not obvious from the root gitignore comment context.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>