### PR TITLE
refactor(transcode): replace any types in Encore methods with generated EncoreJobRequest/Response

### DIFF
--- a/packages/transcode/src/encore.ts
+++ b/packages/transcode/src/encore.ts
@@ -8,6 +8,7 @@ import {
   removeInstance,
   valueOrSecret
 } from '@osaas/client-core';
+import type { EncoreJobResponse } from '@osaas/client-services';
 import { ValkeyDb } from '@osaas/client-db';
 import { delay } from './util';
 
@@ -481,7 +482,7 @@ export class Encore {
     );
     const jobId = Math.random().toString(36).substring(7);
     const encoreJobUrl = new URL('/encoreJobs', instance.url);
-    const data = await createFetch<any>(encoreJobUrl, {
+    const data = await createFetch<EncoreJobResponse>(encoreJobUrl, {
       method: 'POST',
       body: JSON.stringify({
         profile: profile || 'program',
@@ -501,8 +502,7 @@ export class Encore {
         'Content-Type': 'application/json'
       }
     });
-    const encoreJob = JSON.parse(data);
-    Log().debug(encoreJob);
+    Log().debug(data);
   }
 
   public async destroy() {

--- a/packages/transcode/src/index.ts
+++ b/packages/transcode/src/index.ts
@@ -1,6 +1,10 @@
 /** @module @osaas/client-transcode */
 export { EncoreCallbackListener, EncorePackager, Encore } from './encore';
 export type { FileOutput } from './encore';
+export type {
+  EncoreJobRequest,
+  EncoreJobResponse
+} from '@osaas/client-services';
 export { QueuePool } from './pool';
 export { vmafCompare } from './vmaf';
 export { createStreamingPackage } from './packager';

--- a/packages/transcode/src/transcode.ts
+++ b/packages/transcode/src/transcode.ts
@@ -1,5 +1,9 @@
 import { Context, Log } from '@osaas/client-core';
-import { getEncoreInstance } from '@osaas/client-services';
+import {
+  getEncoreInstance,
+  type EncoreJobRequest,
+  type EncoreJobResponse
+} from '@osaas/client-services';
 import { range } from './util';
 
 export interface IDRKeyFrame {
@@ -157,7 +161,18 @@ export async function transcode(
       reconnect_on_network_error: '1'
     };
   }
-  const encoreJob: any = {
+  const encoreJob: Partial<EncoreJobRequest> & {
+    baseName?: string;
+    seekTo?: number;
+    duration?: number;
+    inputs?: { type: string; copyTs?: boolean; uri: string; params?: object }[];
+    profileParams?: {
+      keyframes?: string;
+      audioMixPreset?: string;
+      utcnowstring?: string;
+    };
+    progressCallbackUri?: string;
+  } = {
     externalId: opts.externalId,
     profile,
     baseName,
@@ -183,7 +198,7 @@ export async function transcode(
       const keyframes = opts.injectIDRKeyFrames.map((kf) =>
         smpteTimecodeToFrames(kf.smpteTimeCode, frameRate)
       );
-      encoreJob['profileParams'] = {
+      encoreJob.profileParams = {
         keyframes:
           `expr:not(mod(n,96))` + keyframes.map((f) => `+eq(n,${f})`).join('')
       };
@@ -192,17 +207,17 @@ export async function transcode(
     }
   }
   if (opts.audioMixPreset) {
-    encoreJob['profileParams'] = {
-      ...encoreJob['profileParams'],
+    encoreJob.profileParams = {
+      ...encoreJob.profileParams,
       audioMixPreset: opts.audioMixPreset
     };
   }
   if (opts.callBackUrl) {
-    encoreJob['progressCallbackUri'] = opts.callBackUrl.toString();
+    encoreJob.progressCallbackUri = opts.callBackUrl.toString();
   }
   if (opts.insertCreationDateUtc) {
-    encoreJob['profileParams'] = {
-      ...encoreJob['profileParams'],
+    encoreJob.profileParams = {
+      ...encoreJob.profileParams,
       utcnowstring: formatUtcDateString()
     };
   }
@@ -281,7 +296,7 @@ export async function getTranscodeJob(
 
 interface JobList {
   _embedded: {
-    encoreJobs: any[];
+    encoreJobs: EncoreJobResponse[];
   };
   page: {
     size: number;

--- a/packages/transcode/src/vodpipeline.ts
+++ b/packages/transcode/src/vodpipeline.ts
@@ -21,7 +21,9 @@ import {
   createEyevinnEncoreCallbackListenerInstance,
   createEyevinnEncorePackagerInstance,
   createMinioMinioInstance,
-  createValkeyIoValkeyInstance
+  createValkeyIoValkeyInstance,
+  type EncoreJobRequest,
+  type EncoreJobResponse
 } from '@osaas/client-services';
 import * as Minio from 'minio';
 import { delay } from './util';
@@ -483,7 +485,11 @@ export async function createVod(
   if (sourceUrl.protocol === 's3:' && !pipeline.inputStorage) {
     throw new Error('Input storage bucket required for S3 input');
   }
-  const job = {
+  const job: Partial<EncoreJobRequest> & {
+    baseName?: string;
+    progressCallbackUri?: string;
+    inputs?: { uri: string; seekTo?: number; copyTs?: boolean; type: string }[];
+  } = {
     externalId,
     profile: vodOptions?.profile || 'program',
     outputFolder: '/usercontent/',
@@ -507,7 +513,7 @@ export async function createVod(
     body: JSON.stringify(job)
   });
   if (response.ok) {
-    const createdJob = (await response.json()) as { id: string };
+    const createdJob = (await response.json()) as EncoreJobResponse;
     const sourceName = basename(source, extname(source));
     const outputFolder = new URL(pipeline.output).pathname;
     const vod = {
@@ -516,7 +522,7 @@ export async function createVod(
         pipeline.outputBucketName,
         outputFolder,
         sourceName,
-        createdJob.id,
+        createdJob.id!,
         'index.m3u8'
       )}`
     };


### PR DESCRIPTION
## Summary

Replaces implicit `any` types in the transcode package with generated Encore types from `@osaas/client-services`.

Changes:
- `encore.ts`: `createFetch<any>` -> `createFetch<EncoreJobResponse>` with explicit import
- `transcode.ts`: `encoreJobs: any[]` in `JobList` -> `encoreJobs: EncoreJobResponse[]`; job body typed as `Partial<EncoreJobRequest>` with field intersections for fields not yet in the generated schema
- `vodpipeline.ts`: job body typed as `Partial<EncoreJobRequest>` with field intersections; response cast as `EncoreJobResponse`
- `index.ts`: re-exports `EncoreJobRequest` and `EncoreJobResponse` for package consumers

Closes #133
Part of Eyevinn/osaas-app#4345

## Lessons

`EncoreJobRequest` aliases the POST request body from the OpenAPI spec, which does not include some fields used at the call sites (`baseName`, `seekTo`, `inputs`, `progressCallbackUri`, `profileParams`). These are real fields accepted by Encore but not yet reflected in the generated spec. The approach used is `Partial<EncoreJobRequest> & { fieldA?: type; ... }` which keeps the typed fields type-safe without erroring on the extra fields. Attempting to use `EncoreJobRequest` directly would fail TypeScript with missing required fields. `EncoreJobResponse` resolves to `EntityModelEncoreJob` which has `id` as a direct optional field — no HAL nesting issue.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>