### PR TITLE
fix(core): check job.health field in waitForJobToComplete for pod-status health sources

### DIFF
--- a/packages/core/src/job.test.ts
+++ b/packages/core/src/job.test.ts
@@ -64,6 +64,45 @@ describe('waitForJobToComplete', () => {
     expect(mockGetInstance).toHaveBeenCalledTimes(1);
   });
 
+  test('resolves when job health is SuccessCriteriaMet (status field absent)', async () => {
+    const completedJob = { name: 'myjob', health: 'SuccessCriteriaMet' };
+    mockGetInstance.mockResolvedValue(completedJob);
+    const result = await waitForJobToComplete(
+      ctx,
+      'eyevinn-ffmpeg-s3',
+      'myjob',
+      'token'
+    );
+    expect(result).toEqual(completedJob);
+    expect(mockGetInstance).toHaveBeenCalledTimes(1);
+  });
+
+  test('resolves when job health is Complete (status field absent)', async () => {
+    const completedJob = { name: 'myjob', health: 'Complete' };
+    mockGetInstance.mockResolvedValue(completedJob);
+    const result = await waitForJobToComplete(
+      ctx,
+      'eyevinn-ffmpeg-s3',
+      'myjob',
+      'token'
+    );
+    expect(result).toEqual(completedJob);
+  });
+
+  test('throws when job health is Failed (status field absent)', async () => {
+    mockGetInstance.mockResolvedValue({ health: 'Failed' });
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-ffmpeg-s3', 'myjob', 'token')
+    ).rejects.toThrow("Job 'myjob' failed with status: Failed");
+  });
+
+  test('throws when job health is FailureTarget (status field absent)', async () => {
+    mockGetInstance.mockResolvedValue({ health: 'FailureTarget' });
+    await expect(
+      waitForJobToComplete(ctx, 'eyevinn-ffmpeg-s3', 'myjob', 'token')
+    ).rejects.toThrow("Job 'myjob' failed with status: FailureTarget");
+  });
+
   test('polls until job reaches terminal status', async () => {
     const completedJob = { name: 'myjob', status: 'SuccessCriteriaMet' };
     mockGetInstance

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -142,8 +142,8 @@ export interface WaitForJobOptions {
  * @throws {Error} If the job reaches a terminal failure state ('Failed' or 'FailureTarget')
  * @throws {Error} If timeoutMs is set and the job does not complete within the given time
  *
- * Terminal success statuses: 'Complete', 'SuccessCriteriaMet'
- * Terminal failure statuses: 'Failed', 'FailureTarget'
+ * Terminal success statuses (status or health field): 'Complete', 'SuccessCriteriaMet'
+ * Terminal failure statuses (status or health field): 'Failed', 'FailureTarget'
  */
 export async function waitForJobToComplete(
   context: Context,
@@ -162,11 +162,14 @@ export async function waitForJobToComplete(
       throw new Error(`Job '${name}' timed out after ${options!.timeoutMs}ms`);
     }
     const job = await getJob(context, serviceId, name, token);
-    if (job.status === 'Complete' || job.status === 'SuccessCriteriaMet') {
+    const terminalSuccess = new Set(['Complete', 'SuccessCriteriaMet']);
+    const terminalFailure = new Set(['Failed', 'FailureTarget']);
+    if (terminalSuccess.has(job.status) || terminalSuccess.has(job.health)) {
       return job;
     }
-    if (job.status === 'Failed' || job.status === 'FailureTarget') {
-      throw new Error(`Job '${name}' failed with status: ${job.status}`);
+    if (terminalFailure.has(job.status) || terminalFailure.has(job.health)) {
+      const signal = terminalFailure.has(job.status) ? job.status : job.health;
+      throw new Error(`Job '${name}' failed with status: ${signal}`);
     }
     await delay(1000);
   }


### PR DESCRIPTION
## Summary

- `waitForJobToComplete` now checks both `job.status` and `job.health` against terminal success/failure sets
- Services like `eyevinn-ffmpeg-s3` that use a pod-status health source signal completion via `job.health === 'SuccessCriteriaMet'` — `job.status` is never set to a terminal value for these services
- Failure via `job.health` (e.g. `'Failed'`, `'FailureTarget'`) is also detected and thrown correctly

## Root cause

The previous fix (#129) added `SuccessCriteriaMet` as a recognised `job.status` value. However for `eyevinn-ffmpeg-s3` the orchestrator never sets `job.status` to `SuccessCriteriaMet` — it sets `job.health` instead. The two fields are populated by different health sources and are independent.

## Test plan

- [x] Existing status-based tests still pass
- [x] New tests: `job.health === 'SuccessCriteriaMet'` resolves, `job.health === 'Complete'` resolves, `job.health === 'Failed'` throws, `job.health === 'FailureTarget'` throws

Closes #143

## Lessons

`job.status` and `job.health` are populated by different orchestrator health sources and are independent — a service can have a terminal `health` value while `status` stays non-terminal. Any completion predicate must check both fields.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>