### PR TITLE
fix(db): use http:// for private couchdb internal endpoint URL

### DIFF
--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -1,0 +1,68 @@
+import { Context, getInternalEndpoint } from '@osaas/client-core';
+import { getApacheCouchdbInstance } from '@osaas/client-services';
+import { setupDatabase } from '.';
+
+jest.mock('@osaas/client-core', () => {
+  return {
+    getInternalEndpoint: jest.fn(),
+    getPortsForInstance: jest.fn(),
+    Context: jest.fn().mockImplementation(() => {
+      return {
+        getServiceAccessToken: jest.fn().mockResolvedValue('token')
+      };
+    })
+  };
+});
+
+jest.mock('@osaas/client-services', () => {
+  return {
+    getApacheCouchdbInstance: jest.fn(),
+    createApacheCouchdbInstance: jest.fn()
+  };
+});
+
+describe('setupDatabase couchdb', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an http:// URL for a private (publicAccess: false) instance', async () => {
+    (getApacheCouchdbInstance as jest.Mock).mockResolvedValue({
+      name: 'myinstance',
+      url: 'https://myinstance.apache-couchdb.auto.dev.osaas.io',
+      AdminPassword: 'secret'
+    });
+    (getInternalEndpoint as jest.Mock).mockResolvedValue({
+      serviceDns: 'myinstance.apache-couchdb.svc.cluster.local',
+      ports: [{ name: 'couchdb', port: 5984, protocol: 'TCP' }],
+      publicAccess: false
+    });
+
+    const ctx = new Context();
+    const url = await setupDatabase(ctx, 'couchdb', 'myinstance', {
+      rootPassword: 'secret',
+      publicAccess: false
+    });
+
+    expect(url).toMatch(/^http:\/\//);
+    expect(url).toBe(
+      'http://admin:secret@myinstance.apache-couchdb.svc.cluster.local:5984'
+    );
+  });
+
+  it('returns an https:// URL for a public instance', async () => {
+    (getApacheCouchdbInstance as jest.Mock).mockResolvedValue({
+      name: 'myinstance',
+      url: 'https://myinstance.apache-couchdb.auto.dev.osaas.io',
+      AdminPassword: 'secret'
+    });
+
+    const ctx = new Context();
+    const url = await setupDatabase(ctx, 'couchdb', 'myinstance', {
+      rootPassword: 'secret'
+    });
+
+    expect(url).toMatch(/^https:\/\//);
+    expect(getInternalEndpoint).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -54,6 +54,22 @@ export const DatabaseTypeToProtocol: Record<DatabaseType, string> = {
   couchdb: 'https'
 };
 
+/**
+ * Protocol to use when connecting to the *internal* (cluster-local) endpoint
+ * of a database, as opposed to its public ingress URL.
+ *
+ * This only needs an entry for database types whose `DatabaseTypeToProtocol`
+ * value is not valid for the raw container port. CouchDB's public URL is
+ * HTTPS (TLS terminated at the ingress on port 443), but its internal
+ * container port (5984) speaks plaintext HTTP - there is no in-cluster TLS
+ * termination on that port. Other database types use non-HTTP schemes
+ * (postgres://, mysql://, redis://, clickhouse://) for both paths and are
+ * unaffected.
+ */
+const DatabaseTypeToInternalProtocol: Partial<Record<DatabaseType, string>> = {
+  couchdb: 'http'
+};
+
 export interface DatabaseOpts {
   username?: string;
   password?: string;
@@ -259,7 +275,7 @@ export async function setupDatabase(
           (p) => p.port === DatabaseTypeToPort['couchdb']
         );
         if (port) {
-          return `${DatabaseTypeToProtocol['couchdb']}://admin:${
+          return `${DatabaseTypeToInternalProtocol['couchdb']}://admin:${
             (instance as any).AdminPassword
           }@${endpointInfo.serviceDns}:${port.port}`;
         }


### PR DESCRIPTION
## Summary

`setupDatabase()` in `@osaas/client-db` built an `https://` connection URL for CouchDB's **internal** (`publicAccess: false`) endpoint by reusing `DatabaseTypeToProtocol['couchdb']`, which is `'https'` and correct only for the **public** ingress URL (port 443, TLS terminated at the ingress). The internal container port `5984` speaks plaintext HTTP — there is no in-cluster TLS termination on that port — so any consumer given this URL fails with a TLS-handshake-on-plaintext-port error.

## Fix

- Added a separate `DatabaseTypeToInternalProtocol` lookup (currently only overriding `couchdb` -> `http`) so the internal-endpoint branch for CouchDB emits `http://` instead of reusing the ingress-only `DatabaseTypeToProtocol` constant.
- `DatabaseTypeToProtocol['couchdb']` is unchanged (`'https'`) since it is still correct for the public path.
- Other database types (postgres, mysql, redis, clickhouse) are unaffected — their internal paths already use non-HTTP schemes.
- Added `packages/db/src/index.test.ts` asserting: private CouchDB URL starts with `http://`, public CouchDB URL starts with `https://`.

## Versioning

I did not manually bump `packages/db/package.json`. I checked the history of prior bug-fix commits touching this file (e.g. `bb115de "fix: clickhouse js client expect http url"`) and none of them touched `package.json` — this repo bumps versions separately via `lerna version --conventional-commits` in dedicated `chore(release): publish` commits, driven by the `fix:`/`feat:` commit prefix. This commit uses a `fix:` prefix so it will be picked up as a patch bump by that process.

Fixes #145

## Lessons

The repo's `packages/*/lib` build output is gitignored but was stale in this checkout (missing `getInternalEndpoint` in `@osaas/client-core`'s compiled `lib/`, even though it exists in `src/`), which made the new Jest test fail to type-check until `packages/core` was rebuilt with `tsc`. Also, despite the task brief suggesting a version bump, this repo's actual convention (verified via `git log` on prior fix commits) is to never bump `package.json` in feature/fix PRs — versioning is automated by `lerna version --conventional-commits` in separate release commits.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>