### PR TITLE
fix: split platform control-plane env from site env in Context

### DIFF
--- a/packages/core/src/admin.ts
+++ b/packages/core/src/admin.ts
@@ -49,7 +49,7 @@ export async function listSubscriptions(
   context: Context
 ): Promise<Subscription[]> {
   const serviceUrl = new URL(
-    `https://catalog.svc.${context.getEnvironment()}.osaas.io/mysubscriptions`
+    `https://catalog.svc.${context.getPlatformEnvironment()}.osaas.io/mysubscriptions`
   );
 
   return await createFetch<Subscription[]>(serviceUrl, {
@@ -73,7 +73,7 @@ export async function removeSubscription(
   serviceId: string
 ): Promise<void> {
   const serviceUrl = new URL(
-    `https://catalog.svc.${context.getEnvironment()}.osaas.io/mysubscriptions/${serviceId}`
+    `https://catalog.svc.${context.getPlatformEnvironment()}.osaas.io/mysubscriptions/${serviceId}`
   );
 
   await createFetch<{ reason: string } | string>(serviceUrl, {

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -1,0 +1,70 @@
+import { Context, PRIMARY_ENV, PROD_SITE_ENVS } from './context';
+
+describe('Context environment / platformEnv split', () => {
+  test('defaults environment to prod when not provided', () => {
+    const ctx = new Context({ personalAccessToken: 'dummy' });
+    expect(ctx.getEnvironment()).toBe('prod');
+    expect(ctx.getPlatformEnvironment()).toBe('prod');
+  });
+
+  test('platformEnv defaults to PRIMARY_ENV when environment is prod-se', () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'prod-se'
+    });
+    expect(ctx.getEnvironment()).toBe('prod-se');
+    expect(ctx.getPlatformEnvironment()).toBe(PRIMARY_ENV);
+    expect(ctx.getPlatformEnvironment()).toBe('prod');
+  });
+
+  test('platformEnv defaults to prod when environment is prod', () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'prod'
+    });
+    expect(ctx.getEnvironment()).toBe('prod');
+    expect(ctx.getPlatformEnvironment()).toBe('prod');
+  });
+
+  test('platformEnv stays on dev when environment is dev (independent environment, no site split)', () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'dev'
+    });
+    expect(ctx.getEnvironment()).toBe('dev');
+    expect(ctx.getPlatformEnvironment()).toBe('dev');
+  });
+
+  test('platformEnv stays on stage when environment is stage (independent environment, no site split)', () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'stage'
+    });
+    expect(ctx.getEnvironment()).toBe('stage');
+    expect(ctx.getPlatformEnvironment()).toBe('stage');
+  });
+
+  test('an explicit platformEnv override always wins, even for prod-se', () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'prod-se',
+      platformEnv: 'custom-control-plane'
+    });
+    expect(ctx.getEnvironment()).toBe('prod-se');
+    expect(ctx.getPlatformEnvironment()).toBe('custom-control-plane');
+  });
+
+  test('an explicit platformEnv override works for dev too', () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'dev',
+      platformEnv: 'custom-control-plane'
+    });
+    expect(ctx.getEnvironment()).toBe('dev');
+    expect(ctx.getPlatformEnvironment()).toBe('custom-control-plane');
+  });
+
+  test('PROD_SITE_ENVS contains exactly prod and prod-se', () => {
+    expect(PROD_SITE_ENVS).toEqual(['prod', 'prod-se']);
+  });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,8 +1,40 @@
 import { createFetch } from './fetch';
 
+/**
+ * The primary environment that hosts the authoritative platform control
+ * plane (catalog-manager, token-service, money-manager) for the prod site
+ * group. `prod-se` (Elastx) is a secondary site of this environment, not
+ * an independent peer environment. Auth/entitlement calls made from a
+ * `prod-se` context must always target the primary environment regardless
+ * of which site a service instance is hosted on.
+ */
+export const PRIMARY_ENV = process.env.OSC_PRIMARY_ENV || 'prod';
+
+/**
+ * Environments that are sites of the same prod control plane rather than
+ * independent environments. `dev` and `stage` are each a single,
+ * self-contained cluster with their own catalog-manager/token-service, so
+ * they are intentionally excluded here: platform calls made from a `dev`
+ * or `stage` context must stay on `dev`/`stage`, not get redirected to
+ * `prod`.
+ */
+export const PROD_SITE_ENVS = ['prod', 'prod-se'];
+
 export type ContextConfig = {
   personalAccessToken?: string;
   environment?: string;
+  /**
+   * The environment to use for platform/auth calls (subscription checks,
+   * service access token minting). Defaults to PRIMARY_ENV when
+   * `environment` is a prod-site environment (`prod` or `prod-se`), so that
+   * platform calls always reach the authoritative control plane even when
+   * `environment` is set to a secondary site (e.g. `prod-se`). For `dev`
+   * and `stage`, defaults to `environment` unchanged, since those are
+   * independent environments with their own control plane. Only override
+   * this if you explicitly need to target a non-default platform control
+   * plane.
+   */
+  platformEnv?: string;
 };
 
 export type ServiceAccessToken = {
@@ -25,6 +57,7 @@ export type Subscriptions = {
 export class Context {
   private personalAccessToken?: string;
   private environment: string;
+  private platformEnv: string;
 
   constructor(config?: ContextConfig) {
     if (!config?.personalAccessToken && !process.env.OSC_ACCESS_TOKEN) {
@@ -37,6 +70,14 @@ export class Context {
       ? config.personalAccessToken
       : process.env.OSC_ACCESS_TOKEN;
     this.environment = config?.environment ? config.environment : 'prod';
+    // Only `prod`/`prod-se` collapse onto PRIMARY_ENV. A caller on `dev`
+    // or `stage` must keep platform calls on that same environment, not
+    // get redirected to `prod`.
+    this.platformEnv = config?.platformEnv
+      ? config.platformEnv
+      : PROD_SITE_ENVS.includes(this.environment)
+      ? PRIMARY_ENV
+      : this.environment;
   }
 
   getPersonalAccessToken() {
@@ -47,9 +88,13 @@ export class Context {
     return this.environment;
   }
 
+  getPlatformEnvironment() {
+    return this.platformEnv;
+  }
+
   async getServiceAccessToken(serviceId: string): Promise<string> {
     const serviceUrl = new URL(
-      `https://catalog.svc.${this.environment}.osaas.io/mysubscriptions`
+      `https://catalog.svc.${this.platformEnv}.osaas.io/mysubscriptions`
     );
     const services = await createFetch<Service[]>(serviceUrl, {
       method: 'GET',
@@ -64,7 +109,7 @@ export class Context {
     }
 
     const satUrl = new URL(
-      `https://token.svc.${this.environment}.osaas.io/servicetoken`
+      `https://token.svc.${this.platformEnv}.osaas.io/servicetoken`
     );
     const serviceAccessToken = await createFetch<ServiceAccessToken>(satUrl, {
       method: 'POST',
@@ -79,7 +124,7 @@ export class Context {
 
   async activateService(serviceId: string) {
     const serviceUrl = new URL(
-      `https://catalog.svc.${this.environment}.osaas.io/mysubscriptions`
+      `https://catalog.svc.${this.platformEnv}.osaas.io/mysubscriptions`
     );
     await createFetch<Subscriptions>(serviceUrl, {
       method: 'POST',

--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -1,5 +1,10 @@
 import { Context } from './context';
-import { createInstance, isValidInstanceName, removeInstance } from './core';
+import {
+  createInstance,
+  isValidInstanceName,
+  removeInstance,
+  saveSecret
+} from './core';
 import { InvalidName } from './errors';
 import { createFetch, FetchError } from './fetch';
 
@@ -107,5 +112,34 @@ describe('removeInstance', () => {
     await expect(
       removeInstance(ctx, 'eyevinn-test-adserver', 'myinstance', 'my-token')
     ).rejects.toThrow(FetchError);
+  });
+});
+
+describe('site-scoped calls (deploy-manager) still use environment, not platformEnv', () => {
+  const mockCreateFetch = createFetch as jest.MockedFunction<
+    typeof createFetch
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('saveSecret targets deploy.svc.<environment>, not platformEnv, even when they diverge on prod-se', async () => {
+    const ctx = new Context({
+      personalAccessToken: 'dummy',
+      environment: 'prod-se'
+    });
+    // platformEnv should have collapsed to 'prod' for this context, while
+    // environment (site) stays 'prod-se' — saveSecret must follow the site.
+    expect(ctx.getPlatformEnvironment()).toBe('prod');
+    expect(ctx.getEnvironment()).toBe('prod-se');
+
+    mockCreateFetch.mockResolvedValueOnce(undefined);
+
+    await saveSecret('eyevinn-test-adserver', 'my-secret', 'value', ctx);
+
+    expect(mockCreateFetch).toHaveBeenCalledTimes(1);
+    const calledUrl = mockCreateFetch.mock.calls[0][0] as URL;
+    expect(calledUrl.hostname).toBe('deploy.svc.prod-se.osaas.io');
   });
 });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -7,7 +7,7 @@ const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 export async function getService(context: Context, serviceId: string) {
   const serviceUrl = new URL(
-    `https://catalog.svc.${context.getEnvironment()}.osaas.io/mysubscriptions`
+    `https://catalog.svc.${context.getPlatformEnvironment()}.osaas.io/mysubscriptions`
   );
   const services = await createFetch<Service[]>(serviceUrl, {
     method: 'GET',


### PR DESCRIPTION
## Summary

Closes #147.

MyApps running on Elastx (`prod-se`) fail to fetch their env vars from `eyevinn-app-config-svc` at container startup whenever Elastx's own `catalog-manager`/`token-service`/`money-manager` are down (e.g. during migration/scale-down ops) — even though the actual data source (the tenant's app-config-svc instance) is healthy and reachable throughout. Confirmed root cause during a 2026-07-29 11:40–13:04 UTC production incident.

`prod-se` (Elastx) is a **site** of the single `prod` environment, not an independent peer environment — `infra-osaas/osaas/prod-estx.yml` declares `environment: "prod"` on every Elastx platform ConfigMap, and `pat-secret`/`mac-keys` are byte-identical across both clusters. `Context` previously reused one `environment` value for both site resolution (which cluster hosts the instance data — already fully data-driven via `service.apiUrl`) and platform/auth calls (subscription check + SAT mint). A context configured with `environment=prod-se` therefore called Elastx's **own** catalog-manager and token-service, which pull in Elastx's own money-manager over in-cluster DNS with no cross-cluster fallback — turning a transient Elastx control-plane blip into a MyApp startup outage.

## Changes

- `packages/core/src/context.ts`: split `Context` into `environment` (site) and a new `platformEnv` (control plane). Added `PRIMARY_ENV` (`process.env.OSC_PRIMARY_ENV || 'prod'`) and `PROD_SITE_ENVS = ['prod', 'prod-se']`. `platformEnv` defaults to `PRIMARY_ENV` **only** when `environment` is `prod` or `prod-se` — `dev` and `stage` are independent single-cluster environments with their own control plane and are intentionally excluded, so `platformEnv` stays equal to `environment` for them. An explicit `config.platformEnv` always wins. Added `getPlatformEnvironment()` accessor. Switched `/mysubscriptions` (GET + POST) and `/servicetoken` to use `platformEnv`.
- `packages/core/src/core.ts`: `getService()`'s `/mysubscriptions` call now uses `context.getPlatformEnvironment()`.
- `packages/core/src/admin.ts`: `listSubscriptions()` and `removeSubscription()`'s `/mysubscriptions` calls now use `context.getPlatformEnvironment()` (same auth/entitlement concern as `context.ts`, previously missed the same coupling).
- **Left unchanged (verified, genuinely site-scoped)**: `core.ts` `saveSecret`/`listSecrets`/`getSecret`/`updateSecret`/`deleteSecret` (`deploy.svc/mysecrets`), `admin.ts` `listReservedNodes` (`deploy.svc/mynodes`), and all of `myapp.ts` (`deploy.svc/myapps`) — deploy-manager owns cluster-local K8s resources per site, so these must keep following `environment`.
- **Out of scope (verified, different mechanism)**: `packages/core/src/platform.ts`'s `Platform` class (used by `packages/cli/src/admin/syncfork.ts` and `packages/core/src/platform/maker.ts` for `maker.svc.*` calls) uses a separate `OSC_API_KEY` auth model for admin/build tooling, not the PAT-based MyApps runtime path implicated in this incident. `packages/ai/src/chat.ts`/`embeddings.ts`'s `ai.svc.${environment}` calls are an application service endpoint, not an auth/entitlement endpoint, and were not touched.

Tests added in `packages/core/src/context.test.ts` cover: default `platformEnv` for `prod`/`prod-se`/`dev`/`stage`, explicit override wins, and `PROD_SITE_ENVS` contents. `packages/core/src/core.test.ts` gained a test confirming `saveSecret` still targets `deploy.svc.<environment>` (site) even when `environment` and `platformEnv` diverge on `prod-se`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` (packages/core) — passes
- [x] `npx eslint src/context.ts src/context.test.ts src/core.ts src/core.test.ts src/admin.ts` — 0 errors (6 pre-existing `no-explicit-any` warnings in unrelated lines of `core.ts`)
- [x] `npx prettier --check` on all changed files — passes
- [x] `npx jest` (packages/core, full suite) — 33/33 passing, including new tests

## Lessons

A previous investigation session's `git pull --ff-only` on all five runner repos (web/python/golang/dotnet/wasm-runner) returned quietly without actually fast-forwarding, leaving those checkouts 3-5 commits behind `origin/main` and producing a false "no `--env` flag propagated" conclusion. `git pull` succeeding is not sufficient confirmation of being current — always follow with `git rev-list --count HEAD..origin/main` and confirm it's `0` before drawing conclusions from a local checkout. Applied here: `client-ts` was confirmed at `0` commits behind before any file was read.

Separately, the original fix instructions assumed `platformEnv` should unconditionally default to `PRIMARY_ENV`. That's correct for `prod`/`prod-se` but wrong for `dev`/`stage`, which are genuinely independent single-cluster environments with their own control plane — unconditionally forcing them onto `prod` would have broken dev/stage platform calls. The `PROD_SITE_ENVS` gate (`['prod', 'prod-se']`) exists specifically to scope the redirect to the one pair of environments where it applies.

Also worth flagging for a follow-up: `admin.ts`'s `listSubscriptions`/`removeSubscription` had the exact same `/mysubscriptions` + `context.getEnvironment()` coupling as `context.ts`, and would have silently kept the same bug for anyone managing subscriptions from a `prod-se`-configured `Context` if not caught by grepping the whole `packages/core/src` tree for all `/mysubscriptions` and `/servicetoken` call sites rather than trusting the 4 call sites named in the original bug report.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
